### PR TITLE
fix secret core service cert save path

### DIFF
--- a/custos-core-services/resource-secret-core-service/src/main/java/org/apache/custos/resource/secret/manager/adaptor/outbound/CredentialWriter.java
+++ b/custos-core-services/resource-secret-core-service/src/main/java/org/apache/custos/resource/secret/manager/adaptor/outbound/CredentialWriter.java
@@ -216,7 +216,7 @@ public class CredentialWriter {
 
 
         String path = Constants.VAULT_RESOURCE_SECRETS_PATH + credential.getTenantId() + "/" + credential.getOwnerId() +
-                "/" + Constants.SSH_CREDENTIALS + "/" + credential.getToken();
+                "/" + Constants.CERTIFICATES + "/" + credential.getToken();
 
 
         Certificate certificate = new Certificate(credential.getCert(),


### PR DESCRIPTION
Certificate save path was set to following which is not correct. `Constants.SSH` should be corrected as `Constants.CERTIFICATES`.

```java
 String path = Constants.VAULT_RESOURCE_SECRETS_PATH + credential.getTenantId() + "/" + credential.getOwnerId() +
                "/" + Constants.SSH + "/" + credential.getToken();
```