### PR TITLE
mac m1 protobuf compatibility (ported to baremetal branch)

### DIFF
--- a/custos-client-sdks/custos-java-clients/agent-management-client/pom.xml
+++ b/custos-client-sdks/custos-java-clients/agent-management-client/pom.xml
@@ -101,9 +101,9 @@
                 <groupId>org.xolstice.maven.plugins</groupId>
                 <artifactId>protobuf-maven-plugin</artifactId>
                 <configuration>
-                    <protocArtifact>com.google.protobuf:protoc:3.0.2:exe:${os.detected.classifier}</protocArtifact>
+                    <protocArtifact>com.google.protobuf:protoc:${com.google.protobuf.util}:exe:${os.detected.classifier}</protocArtifact>
                     <pluginId>grpc-java</pluginId>
-                    <pluginArtifact>io.grpc:protoc-gen-grpc-java:1.0.1:exe:${os.detected.classifier}</pluginArtifact>
+                    <pluginArtifact>io.grpc:protoc-gen-grpc-java:${io.grpc.version}:exe:${os.detected.classifier}</pluginArtifact>
                     <protoSourceRoot>
                         ../../../custos-services/custos-integration-services/agent-management-service/src/main/proto
                     </protoSourceRoot>

--- a/custos-client-sdks/custos-java-clients/group-management-client/pom.xml
+++ b/custos-client-sdks/custos-java-clients/group-management-client/pom.xml
@@ -100,9 +100,9 @@
                 <groupId>org.xolstice.maven.plugins</groupId>
                 <artifactId>protobuf-maven-plugin</artifactId>
                 <configuration>
-                    <protocArtifact>com.google.protobuf:protoc:3.0.2:exe:${os.detected.classifier}</protocArtifact>
+                    <protocArtifact>com.google.protobuf:protoc:${com.google.protobuf.util}:exe:${os.detected.classifier}</protocArtifact>
                     <pluginId>grpc-java</pluginId>
-                    <pluginArtifact>io.grpc:protoc-gen-grpc-java:1.0.1:exe:${os.detected.classifier}</pluginArtifact>
+                    <pluginArtifact>io.grpc:protoc-gen-grpc-java:${io.grpc.version}:exe:${os.detected.classifier}</pluginArtifact>
                     <protoSourceRoot>
                         ../../../custos-services/custos-integration-services/group-management-service/src/main/proto
                     </protoSourceRoot>

--- a/custos-client-sdks/custos-java-clients/identity-management-client/pom.xml
+++ b/custos-client-sdks/custos-java-clients/identity-management-client/pom.xml
@@ -103,9 +103,9 @@
                 <groupId>org.xolstice.maven.plugins</groupId>
                 <artifactId>protobuf-maven-plugin</artifactId>
                 <configuration>
-                    <protocArtifact>com.google.protobuf:protoc:3.0.2:exe:${os.detected.classifier}</protocArtifact>
+                    <protocArtifact>com.google.protobuf:protoc:${com.google.protobuf.util}:exe:${os.detected.classifier}</protocArtifact>
                     <pluginId>grpc-java</pluginId>
-                    <pluginArtifact>io.grpc:protoc-gen-grpc-java:1.0.1:exe:${os.detected.classifier}</pluginArtifact>
+                    <pluginArtifact>io.grpc:protoc-gen-grpc-java:${io.grpc.version}:exe:${os.detected.classifier}</pluginArtifact>
                     <protoSourceRoot>../../../custos-services/custos-integration-services/identity-management-service/src/main/proto</protoSourceRoot>
                 </configuration>
                 <executions>

--- a/custos-client-sdks/custos-java-clients/resource-secret-management-client/pom.xml
+++ b/custos-client-sdks/custos-java-clients/resource-secret-management-client/pom.xml
@@ -106,9 +106,9 @@
                 <groupId>org.xolstice.maven.plugins</groupId>
                 <artifactId>protobuf-maven-plugin</artifactId>
                 <configuration>
-                    <protocArtifact>com.google.protobuf:protoc:3.0.2:exe:${os.detected.classifier}</protocArtifact>
+                    <protocArtifact>com.google.protobuf:protoc:${com.google.protobuf.util}:exe:${os.detected.classifier}</protocArtifact>
                     <pluginId>grpc-java</pluginId>
-                    <pluginArtifact>io.grpc:protoc-gen-grpc-java:1.0.1:exe:${os.detected.classifier}</pluginArtifact>
+                    <pluginArtifact>io.grpc:protoc-gen-grpc-java:${io.grpc.version}:exe:${os.detected.classifier}</pluginArtifact>
                     <protoSourceRoot>
                         ../../../custos-services/custos-integration-services/resource-secret-management-service/src/main/proto
                     </protoSourceRoot>

--- a/custos-client-sdks/custos-java-clients/sharing-management-client/pom.xml
+++ b/custos-client-sdks/custos-java-clients/sharing-management-client/pom.xml
@@ -102,9 +102,9 @@
                 <groupId>org.xolstice.maven.plugins</groupId>
                 <artifactId>protobuf-maven-plugin</artifactId>
                 <configuration>
-                    <protocArtifact>com.google.protobuf:protoc:3.0.2:exe:${os.detected.classifier}</protocArtifact>
+                    <protocArtifact>com.google.protobuf:protoc:${com.google.protobuf.util}:exe:${os.detected.classifier}</protocArtifact>
                     <pluginId>grpc-java</pluginId>
-                    <pluginArtifact>io.grpc:protoc-gen-grpc-java:1.0.1:exe:${os.detected.classifier}</pluginArtifact>
+                    <pluginArtifact>io.grpc:protoc-gen-grpc-java:${io.grpc.version}:exe:${os.detected.classifier}</pluginArtifact>
                     <protoSourceRoot>
                         ../../../custos-services/custos-integration-services/sharing-management-service/src/main/proto
                     </protoSourceRoot>

--- a/custos-client-sdks/custos-java-clients/tenant-management-client/pom.xml
+++ b/custos-client-sdks/custos-java-clients/tenant-management-client/pom.xml
@@ -103,9 +103,9 @@
                 <groupId>org.xolstice.maven.plugins</groupId>
                 <artifactId>protobuf-maven-plugin</artifactId>
                 <configuration>
-                    <protocArtifact>com.google.protobuf:protoc:3.0.2:exe:${os.detected.classifier}</protocArtifact>
+                    <protocArtifact>com.google.protobuf:protoc:${com.google.protobuf.util}:exe:${os.detected.classifier}</protocArtifact>
                     <pluginId>grpc-java</pluginId>
-                    <pluginArtifact>io.grpc:protoc-gen-grpc-java:1.0.1:exe:${os.detected.classifier}</pluginArtifact>
+                    <pluginArtifact>io.grpc:protoc-gen-grpc-java:${io.grpc.version}:exe:${os.detected.classifier}</pluginArtifact>
                     <protoSourceRoot>
                         ../../../custos-services/custos-integration-services/tenant-management-service/src/main/proto
                     </protoSourceRoot>

--- a/custos-client-sdks/custos-java-clients/user-management-client/pom.xml
+++ b/custos-client-sdks/custos-java-clients/user-management-client/pom.xml
@@ -101,9 +101,9 @@
                 <groupId>org.xolstice.maven.plugins</groupId>
                 <artifactId>protobuf-maven-plugin</artifactId>
                 <configuration>
-                    <protocArtifact>com.google.protobuf:protoc:3.0.2:exe:${os.detected.classifier}</protocArtifact>
+                    <protocArtifact>com.google.protobuf:protoc:${com.google.protobuf.util}:exe:${os.detected.classifier}</protocArtifact>
                     <pluginId>grpc-java</pluginId>
-                    <pluginArtifact>io.grpc:protoc-gen-grpc-java:1.0.1:exe:${os.detected.classifier}</pluginArtifact>
+                    <pluginArtifact>io.grpc:protoc-gen-grpc-java:${io.grpc.version}:exe:${os.detected.classifier}</pluginArtifact>
                     <protoSourceRoot>
                         ../../../custos-services/custos-integration-services/user-management-service/src/main/proto
                     </protoSourceRoot>

--- a/custos-core/sharing-core-impl/pom.xml
+++ b/custos-core/sharing-core-impl/pom.xml
@@ -23,8 +23,8 @@
             <artifactId>spring-boot-starter-data-jpa</artifactId>
         </dependency>
         <dependency>
-            <groupId>mysql</groupId>
-            <artifactId>mysql-connector-java</artifactId>
+            <groupId>io.grpc</groupId>
+            <artifactId>grpc-protobuf</artifactId>
         </dependency>
         <dependency>
             <groupId>jakarta.persistence</groupId>

--- a/custos-services/custos-core-services-client-stubs/agent-profile-core-service-client-stub/pom.xml
+++ b/custos-services/custos-core-services-client-stubs/agent-profile-core-service-client-stub/pom.xml
@@ -71,9 +71,9 @@
                 <groupId>org.xolstice.maven.plugins</groupId>
                 <artifactId>protobuf-maven-plugin</artifactId>
                 <configuration>
-                    <protocArtifact>com.google.protobuf:protoc:3.0.2:exe:${os.detected.classifier}</protocArtifact>
+                    <protocArtifact>com.google.protobuf:protoc:${com.google.protobuf.util}:exe:${os.detected.classifier}</protocArtifact>
                     <pluginId>grpc-java</pluginId>
-                    <pluginArtifact>io.grpc:protoc-gen-grpc-java:1.0.1:exe:${os.detected.classifier}</pluginArtifact>
+                    <pluginArtifact>io.grpc:protoc-gen-grpc-java:${io.grpc.version}:exe:${os.detected.classifier}</pluginArtifact>
                     <protoSourceRoot>../../custos-core-services/agent-profile-core-service/src/main/proto</protoSourceRoot>
                 </configuration>
                 <executions>

--- a/custos-services/custos-core-services-client-stubs/agent-profile-core-service-client-stub/src/main/java/org/apache/custos/agent/profile/client/AgentProfileClient.java
+++ b/custos-services/custos-core-services-client-stubs/agent-profile-core-service-client-stub/src/main/java/org/apache/custos/agent/profile/client/AgentProfileClient.java
@@ -50,7 +50,7 @@ public class AgentProfileClient {
                               @Value("${core.services.server.port:7070}") int servicePort) {
         this.clientInterceptorList = clientInterceptorList;
         managedChannel = ManagedChannelBuilder.forAddress(
-                serviceHost, servicePort).usePlaintext(true).intercept(clientInterceptorList).build();
+                serviceHost, servicePort).usePlaintext().intercept(clientInterceptorList).build();
         agentProfileServiceStub = AgentProfileServiceGrpc.newStub(managedChannel);
         agentProfileServiceBlockingStub = AgentProfileServiceGrpc.newBlockingStub(managedChannel);
     }

--- a/custos-services/custos-core-services-client-stubs/cluster-management-core-service-client-stub/pom.xml
+++ b/custos-services/custos-core-services-client-stubs/cluster-management-core-service-client-stub/pom.xml
@@ -71,9 +71,9 @@
                 <groupId>org.xolstice.maven.plugins</groupId>
                 <artifactId>protobuf-maven-plugin</artifactId>
                 <configuration>
-                    <protocArtifact>com.google.protobuf:protoc:3.0.2:exe:${os.detected.classifier}</protocArtifact>
+                    <protocArtifact>com.google.protobuf:protoc:${com.google.protobuf.util}:exe:${os.detected.classifier}</protocArtifact>
                     <pluginId>grpc-java</pluginId>
-                    <pluginArtifact>io.grpc:protoc-gen-grpc-java:1.0.1:exe:${os.detected.classifier}</pluginArtifact>
+                    <pluginArtifact>io.grpc:protoc-gen-grpc-java:${io.grpc.version}:exe:${os.detected.classifier}</pluginArtifact>
                     <protoSourceRoot>../../custos-core-services/cluster-management-core-service/src/main/proto</protoSourceRoot>
                 </configuration>
                 <executions>

--- a/custos-services/custos-core-services-client-stubs/cluster-management-core-service-client-stub/src/main/java/org/apache/custos/cluster/management/client/ClusterManagementClient.java
+++ b/custos-services/custos-core-services-client-stubs/cluster-management-core-service-client-stub/src/main/java/org/apache/custos/cluster/management/client/ClusterManagementClient.java
@@ -45,7 +45,7 @@ public class ClusterManagementClient {
                                    @Value("${core.services.server.port:7070}") int servicePort) {
         this.clientInterceptorList = clientInterceptorList;
         managedChannel = ManagedChannelBuilder.forAddress(
-                serviceHost, servicePort).usePlaintext(true).intercept(clientInterceptorList).build();
+                serviceHost, servicePort).usePlaintext().intercept(clientInterceptorList).build();
         clusterManagementServiceStub = ClusterManagementServiceGrpc.newStub(managedChannel);
         clusterManagementServiceBlockingStub = ClusterManagementServiceGrpc.newBlockingStub(managedChannel);
     }

--- a/custos-services/custos-core-services-client-stubs/credential-store-core-service-client-stubs/pom.xml
+++ b/custos-services/custos-core-services-client-stubs/credential-store-core-service-client-stubs/pom.xml
@@ -70,9 +70,9 @@
                 <groupId>org.xolstice.maven.plugins</groupId>
                 <artifactId>protobuf-maven-plugin</artifactId>
                 <configuration>
-                    <protocArtifact>com.google.protobuf:protoc:3.0.2:exe:${os.detected.classifier}</protocArtifact>
+                    <protocArtifact>com.google.protobuf:protoc:${com.google.protobuf.util}:exe:${os.detected.classifier}</protocArtifact>
                     <pluginId>grpc-java</pluginId>
-                    <pluginArtifact>io.grpc:protoc-gen-grpc-java:1.0.1:exe:${os.detected.classifier}</pluginArtifact>
+                    <pluginArtifact>io.grpc:protoc-gen-grpc-java:${io.grpc.version}:exe:${os.detected.classifier}</pluginArtifact>
                     <protoSourceRoot>../../custos-core-services/credential-store-core-service/src/main/proto</protoSourceRoot>
                 </configuration>
                 <executions>

--- a/custos-services/custos-core-services-client-stubs/credential-store-core-service-client-stubs/src/main/java/org/apache/custos/credential/store/client/CredentialStoreServiceClient.java
+++ b/custos-services/custos-core-services-client-stubs/credential-store-core-service-client-stubs/src/main/java/org/apache/custos/credential/store/client/CredentialStoreServiceClient.java
@@ -49,7 +49,7 @@ public class CredentialStoreServiceClient {
                                         @Value("${core.services.server.port:7070}") int servicePort) {
         this.clientInterceptorList = clientInterceptorList;
         managedChannel = ManagedChannelBuilder.forAddress(
-                serviceHost, servicePort).usePlaintext(true).intercept(clientInterceptorList).build();
+                serviceHost, servicePort).usePlaintext().intercept(clientInterceptorList).build();
         credentialStoreServiceStub = CredentialStoreServiceGrpc.newStub(managedChannel);
         credentialStoreServiceBlockingStub = CredentialStoreServiceGrpc.newBlockingStub(managedChannel);
     }

--- a/custos-services/custos-core-services-client-stubs/custos-logging-client-stub/pom.xml
+++ b/custos-services/custos-core-services-client-stubs/custos-logging-client-stub/pom.xml
@@ -71,9 +71,9 @@
                 <groupId>org.xolstice.maven.plugins</groupId>
                 <artifactId>protobuf-maven-plugin</artifactId>
                 <configuration>
-                    <protocArtifact>com.google.protobuf:protoc:3.0.2:exe:${os.detected.classifier}</protocArtifact>
+                    <protocArtifact>com.google.protobuf:protoc:${com.google.protobuf.util}:exe:${os.detected.classifier}</protocArtifact>
                     <pluginId>grpc-java</pluginId>
-                    <pluginArtifact>io.grpc:protoc-gen-grpc-java:1.0.1:exe:${os.detected.classifier}</pluginArtifact>
+                    <pluginArtifact>io.grpc:protoc-gen-grpc-java:${io.grpc.version}:exe:${os.detected.classifier}</pluginArtifact>
                     <protoSourceRoot>../../custos-core-services/custos-logging/src/main/proto</protoSourceRoot>
                 </configuration>
                 <executions>

--- a/custos-services/custos-core-services-client-stubs/custos-logging-client-stub/src/main/java/org/apache/custos/logging/client/LoggingClient.java
+++ b/custos-services/custos-core-services-client-stubs/custos-logging-client-stub/src/main/java/org/apache/custos/logging/client/LoggingClient.java
@@ -51,7 +51,7 @@ public class LoggingClient {
                          @Value("${core.services.server.port:7070}") int servicePort) {
         this.clientInterceptorList = clientInterceptorList;
         managedChannel = ManagedChannelBuilder.forAddress(
-                serviceHost, servicePort).usePlaintext(true).intercept(clientInterceptorList).build();
+                serviceHost, servicePort).usePlaintext().intercept(clientInterceptorList).build();
         loggingServiceBlockingStub = LoggingServiceGrpc.newBlockingStub(managedChannel);
         loggingServiceFutureStub = LoggingServiceGrpc.newFutureStub(managedChannel);
 

--- a/custos-services/custos-core-services-client-stubs/federated-authentication-core-service-client-stub/pom.xml
+++ b/custos-services/custos-core-services-client-stubs/federated-authentication-core-service-client-stub/pom.xml
@@ -70,9 +70,9 @@
                 <groupId>org.xolstice.maven.plugins</groupId>
                 <artifactId>protobuf-maven-plugin</artifactId>
                 <configuration>
-                    <protocArtifact>com.google.protobuf:protoc:3.0.2:exe:${os.detected.classifier}</protocArtifact>
+                    <protocArtifact>com.google.protobuf:protoc:${com.google.protobuf.util}:exe:${os.detected.classifier}</protocArtifact>
                     <pluginId>grpc-java</pluginId>
-                    <pluginArtifact>io.grpc:protoc-gen-grpc-java:1.0.1:exe:${os.detected.classifier}</pluginArtifact>
+                    <pluginArtifact>io.grpc:protoc-gen-grpc-java:${io.grpc.version}:exe:${os.detected.classifier}</pluginArtifact>
                     <protoSourceRoot>../../custos-core-services/federated-authentication-core-service/src/main/proto</protoSourceRoot>
                 </configuration>
                 <executions>

--- a/custos-services/custos-core-services-client-stubs/federated-authentication-core-service-client-stub/src/main/java/org/apache/custos/federated/authentication/client/FederatedAuthenticationClient.java
+++ b/custos-services/custos-core-services-client-stubs/federated-authentication-core-service-client-stub/src/main/java/org/apache/custos/federated/authentication/client/FederatedAuthenticationClient.java
@@ -48,7 +48,7 @@ public class FederatedAuthenticationClient {
                                          @Value("${core.services.server.port:7070}") int servicePort) {
         this.clientInterceptorList = clientInterceptorList;
         managedChannel = ManagedChannelBuilder.forAddress(
-                serviceHost, servicePort).usePlaintext(true).intercept(clientInterceptorList).build();
+                serviceHost, servicePort).usePlaintext().intercept(clientInterceptorList).build();
         federatedAuthenticationServiceStub = FederatedAuthenticationServiceGrpc.newStub(managedChannel);
         federatedAuthenticationServiceBlockingStub = FederatedAuthenticationServiceGrpc.newBlockingStub(managedChannel);
     }

--- a/custos-services/custos-core-services-client-stubs/iam-admin-core-service-client-stub/pom.xml
+++ b/custos-services/custos-core-services-client-stubs/iam-admin-core-service-client-stub/pom.xml
@@ -70,9 +70,9 @@
                 <groupId>org.xolstice.maven.plugins</groupId>
                 <artifactId>protobuf-maven-plugin</artifactId>
                 <configuration>
-                    <protocArtifact>com.google.protobuf:protoc:3.0.2:exe:${os.detected.classifier}</protocArtifact>
+                    <protocArtifact>com.google.protobuf:protoc:${com.google.protobuf.util}:exe:${os.detected.classifier}</protocArtifact>
                     <pluginId>grpc-java</pluginId>
-                    <pluginArtifact>io.grpc:protoc-gen-grpc-java:1.0.1:exe:${os.detected.classifier}</pluginArtifact>
+                    <pluginArtifact>io.grpc:protoc-gen-grpc-java:${io.grpc.version}:exe:${os.detected.classifier}</pluginArtifact>
                     <protoSourceRoot>../../custos-core-services/iam-admin-core-service/src/main/proto</protoSourceRoot>
                 </configuration>
                 <executions>

--- a/custos-services/custos-core-services-client-stubs/iam-admin-core-service-client-stub/src/main/java/org/apache/custos/iam/admin/client/IamAdminServiceClient.java
+++ b/custos-services/custos-core-services-client-stubs/iam-admin-core-service-client-stub/src/main/java/org/apache/custos/iam/admin/client/IamAdminServiceClient.java
@@ -52,7 +52,7 @@ public class IamAdminServiceClient {
                                  @Value("${iam.server.url:https://localhost/auth}") String url) {
         this.clientInterceptorList = clientInterceptorList;
         managedChannel = ManagedChannelBuilder.forAddress(
-                serviceHost, servicePort).usePlaintext(true).intercept(clientInterceptorList).build();
+                serviceHost, servicePort).usePlaintext().intercept(clientInterceptorList).build();
         iamAdminServiceStub = IamAdminServiceGrpc.newStub(managedChannel);
         iamAdminServiceBlockingStub = IamAdminServiceGrpc.newBlockingStub(managedChannel);
         this.iamServerURL = url;

--- a/custos-services/custos-core-services-client-stubs/identity-core-service-client-stub/pom.xml
+++ b/custos-services/custos-core-services-client-stubs/identity-core-service-client-stub/pom.xml
@@ -69,9 +69,9 @@
                 <groupId>org.xolstice.maven.plugins</groupId>
                 <artifactId>protobuf-maven-plugin</artifactId>
                 <configuration>
-                    <protocArtifact>com.google.protobuf:protoc:3.0.2:exe:${os.detected.classifier}</protocArtifact>
+                    <protocArtifact>com.google.protobuf:protoc:${com.google.protobuf.util}:exe:${os.detected.classifier}</protocArtifact>
                     <pluginId>grpc-java</pluginId>
-                    <pluginArtifact>io.grpc:protoc-gen-grpc-java:1.0.1:exe:${os.detected.classifier}</pluginArtifact>
+                    <pluginArtifact>io.grpc:protoc-gen-grpc-java:${io.grpc.version}:exe:${os.detected.classifier}</pluginArtifact>
                     <protoSourceRoot>../../custos-core-services/identity-core-service/src/main/proto</protoSourceRoot>
                 </configuration>
                 <executions>

--- a/custos-services/custos-core-services-client-stubs/identity-core-service-client-stub/src/main/java/org/apache/custos/identity/client/IdentityClient.java
+++ b/custos-services/custos-core-services-client-stubs/identity-core-service-client-stub/src/main/java/org/apache/custos/identity/client/IdentityClient.java
@@ -49,7 +49,7 @@ public class IdentityClient {
                           @Value("${core.services.server.port:7070}") int servicePort) {
         this.clientInterceptorList = clientInterceptorList;
         managedChannel = ManagedChannelBuilder.forAddress(
-                serviceHost, servicePort).usePlaintext(true).intercept(clientInterceptorList).build();
+                serviceHost, servicePort).usePlaintext().intercept(clientInterceptorList).build();
         identityServiceStub = IdentityServiceGrpc.newStub(managedChannel);
         identityServiceBlockingStub = IdentityServiceGrpc.newBlockingStub(managedChannel);
     }

--- a/custos-services/custos-core-services-client-stubs/messaging-core-service-client-stub/pom.xml
+++ b/custos-services/custos-core-services-client-stubs/messaging-core-service-client-stub/pom.xml
@@ -83,9 +83,9 @@
                 <groupId>org.xolstice.maven.plugins</groupId>
                 <artifactId>protobuf-maven-plugin</artifactId>
                 <configuration>
-                    <protocArtifact>com.google.protobuf:protoc:3.0.2:exe:${os.detected.classifier}</protocArtifact>
+                    <protocArtifact>com.google.protobuf:protoc:${com.google.protobuf.util}:exe:${os.detected.classifier}</protocArtifact>
                     <pluginId>grpc-java</pluginId>
-                    <pluginArtifact>io.grpc:protoc-gen-grpc-java:1.0.1:exe:${os.detected.classifier}</pluginArtifact>
+                    <pluginArtifact>io.grpc:protoc-gen-grpc-java:${io.grpc.version}:exe:${os.detected.classifier}</pluginArtifact>
                     <protoSourceRoot>../../custos-core-services/custos-messaging-core-service/src/main/proto</protoSourceRoot>
                 </configuration>
                 <executions>

--- a/custos-services/custos-core-services-client-stubs/messaging-core-service-client-stub/src/main/java/org/apache/custos/messaging/client/MessagingClient.java
+++ b/custos-services/custos-core-services-client-stubs/messaging-core-service-client-stub/src/main/java/org/apache/custos/messaging/client/MessagingClient.java
@@ -50,7 +50,7 @@ public class MessagingClient {
                            @Value("${core.services.server.port:7070}") int servicePort) {
         this.clientInterceptorList = clientInterceptorList;
         managedChannel = ManagedChannelBuilder.forAddress(
-                serviceHost, servicePort).usePlaintext(true).intercept(clientInterceptorList).build();
+                serviceHost, servicePort).usePlaintext().intercept(clientInterceptorList).build();
         messagingServiceBlockingStub = MessagingServiceGrpc.newBlockingStub(managedChannel);
         messagingServiceFutureStub = MessagingServiceGrpc.newStub(managedChannel);
         emailServiceStub = EmailServiceGrpc.newStub(managedChannel);

--- a/custos-services/custos-core-services-client-stubs/resource-secret-core-service-client-stub/pom.xml
+++ b/custos-services/custos-core-services-client-stubs/resource-secret-core-service-client-stub/pom.xml
@@ -70,9 +70,9 @@
                 <groupId>org.xolstice.maven.plugins</groupId>
                 <artifactId>protobuf-maven-plugin</artifactId>
                 <configuration>
-                    <protocArtifact>com.google.protobuf:protoc:3.0.2:exe:${os.detected.classifier}</protocArtifact>
+                    <protocArtifact>com.google.protobuf:protoc:${com.google.protobuf.util}:exe:${os.detected.classifier}</protocArtifact>
                     <pluginId>grpc-java</pluginId>
-                    <pluginArtifact>io.grpc:protoc-gen-grpc-java:1.0.1:exe:${os.detected.classifier}</pluginArtifact>
+                    <pluginArtifact>io.grpc:protoc-gen-grpc-java:${io.grpc.version}:exe:${os.detected.classifier}</pluginArtifact>
                     <protoSourceRoot>../../custos-core-services/resource-secret-core-service/src/main/proto</protoSourceRoot>
                 </configuration>
                 <executions>

--- a/custos-services/custos-core-services-client-stubs/resource-secret-core-service-client-stub/src/main/java/org/apache/custos/resource/secret/client/ResourceSecretClient.java
+++ b/custos-services/custos-core-services-client-stubs/resource-secret-core-service-client-stub/src/main/java/org/apache/custos/resource/secret/client/ResourceSecretClient.java
@@ -41,7 +41,7 @@ public class ResourceSecretClient {
                                 @Value("${core.services.server.port:7070}") int servicePort) {
         this.clientInterceptorList = clientInterceptorList;
         managedChannel = ManagedChannelBuilder.forAddress(
-                serviceHost, servicePort).usePlaintext(true).intercept(clientInterceptorList).build();
+                serviceHost, servicePort).usePlaintext().intercept(clientInterceptorList).build();
         resourceSecretServiceBlockingStub = ResourceSecretServiceGrpc.newBlockingStub(managedChannel);
     }
 

--- a/custos-services/custos-core-services-client-stubs/sharing-core-service-client-stub/pom.xml
+++ b/custos-services/custos-core-services-client-stubs/sharing-core-service-client-stub/pom.xml
@@ -77,9 +77,9 @@
                 <groupId>org.xolstice.maven.plugins</groupId>
                 <artifactId>protobuf-maven-plugin</artifactId>
                 <configuration>
-                    <protocArtifact>com.google.protobuf:protoc:3.0.2:exe:${os.detected.classifier}</protocArtifact>
+                    <protocArtifact>com.google.protobuf:protoc:${com.google.protobuf.util}:exe:${os.detected.classifier}</protocArtifact>
                     <pluginId>grpc-java</pluginId>
-                    <pluginArtifact>io.grpc:protoc-gen-grpc-java:1.0.1:exe:${os.detected.classifier}</pluginArtifact>
+                    <pluginArtifact>io.grpc:protoc-gen-grpc-java:${io.grpc.version}:exe:${os.detected.classifier}</pluginArtifact>
                     <protoSourceRoot>../../../custos-grpc-data-models/proto</protoSourceRoot>
                 </configuration>
                 <executions>

--- a/custos-services/custos-core-services-client-stubs/sharing-core-service-client-stub/src/main/java/org/apache/custos/sharing/client/SharingClient.java
+++ b/custos-services/custos-core-services-client-stubs/sharing-core-service-client-stub/src/main/java/org/apache/custos/sharing/client/SharingClient.java
@@ -47,7 +47,7 @@ public class SharingClient {
                          @Value("${core.services.server.port:7070}") int servicePort) {
         this.clientInterceptorList = clientInterceptorList;
         managedChannel = ManagedChannelBuilder.forAddress(
-                serviceHost, servicePort).usePlaintext(true).intercept(clientInterceptorList).build();
+                serviceHost, servicePort).usePlaintext().intercept(clientInterceptorList).build();
         sharingServiceBlockingStub = SharingServiceGrpc.newBlockingStub(managedChannel);
 
     }

--- a/custos-services/custos-core-services-client-stubs/tenant-profile-core-service-client-stub/pom.xml
+++ b/custos-services/custos-core-services-client-stubs/tenant-profile-core-service-client-stub/pom.xml
@@ -72,9 +72,9 @@
           <groupId>org.xolstice.maven.plugins</groupId>
           <artifactId>protobuf-maven-plugin</artifactId>
           <configuration>
-              <protocArtifact>com.google.protobuf:protoc:3.0.2:exe:${os.detected.classifier}</protocArtifact>
+              <protocArtifact>com.google.protobuf:protoc:${com.google.protobuf.util}:exe:${os.detected.classifier}</protocArtifact>
               <pluginId>grpc-java</pluginId>
-              <pluginArtifact>io.grpc:protoc-gen-grpc-java:1.0.1:exe:${os.detected.classifier}</pluginArtifact>
+              <pluginArtifact>io.grpc:protoc-gen-grpc-java:${io.grpc.version}:exe:${os.detected.classifier}</pluginArtifact>
               <protoSourceRoot>../../custos-core-services/tenant-profile-core-service/src/main/proto</protoSourceRoot>
           </configuration>
           <executions>

--- a/custos-services/custos-core-services-client-stubs/tenant-profile-core-service-client-stub/src/main/java/org/apache/custos/tenant/profile/client/async/TenantProfileClient.java
+++ b/custos-services/custos-core-services-client-stubs/tenant-profile-core-service-client-stub/src/main/java/org/apache/custos/tenant/profile/client/async/TenantProfileClient.java
@@ -51,7 +51,7 @@ public class TenantProfileClient {
                                @Value("${core.services.server.port:7070}") int servicePort) {
         this.clientInterceptorList = clientInterceptorList;
         managedChannel = ManagedChannelBuilder.forAddress(
-                serviceHost, servicePort).usePlaintext(true).intercept(clientInterceptorList).build();
+                serviceHost, servicePort).usePlaintext().intercept(clientInterceptorList).build();
         profileServiceStub = TenantProfileServiceGrpc.newStub(managedChannel);
         profileServiceBlockingStub = TenantProfileServiceGrpc.newBlockingStub(managedChannel);
     }

--- a/custos-services/custos-core-services-client-stubs/user-profile-core-service-client-stub/pom.xml
+++ b/custos-services/custos-core-services-client-stubs/user-profile-core-service-client-stub/pom.xml
@@ -71,9 +71,9 @@
                 <groupId>org.xolstice.maven.plugins</groupId>
                 <artifactId>protobuf-maven-plugin</artifactId>
                 <configuration>
-                    <protocArtifact>com.google.protobuf:protoc:3.0.2:exe:${os.detected.classifier}</protocArtifact>
+                    <protocArtifact>com.google.protobuf:protoc:${com.google.protobuf.util}:exe:${os.detected.classifier}</protocArtifact>
                     <pluginId>grpc-java</pluginId>
-                    <pluginArtifact>io.grpc:protoc-gen-grpc-java:1.0.1:exe:${os.detected.classifier}</pluginArtifact>
+                    <pluginArtifact>io.grpc:protoc-gen-grpc-java:${io.grpc.version}:exe:${os.detected.classifier}</pluginArtifact>
                     <protoSourceRoot>../../custos-core-services/user-profile-core-service/src/main/proto</protoSourceRoot>
                 </configuration>
                 <executions>

--- a/custos-services/custos-core-services-client-stubs/user-profile-core-service-client-stub/src/main/java/org/apache/custos/user/profile/client/UserProfileClient.java
+++ b/custos-services/custos-core-services-client-stubs/user-profile-core-service-client-stub/src/main/java/org/apache/custos/user/profile/client/UserProfileClient.java
@@ -50,7 +50,7 @@ public class UserProfileClient {
                              @Value("${core.services.server.port:7070}") int servicePort) {
         this.clientInterceptorList = clientInterceptorList;
         managedChannel = ManagedChannelBuilder.forAddress(
-                serviceHost, servicePort).usePlaintext(true).intercept(clientInterceptorList).build();
+                serviceHost, servicePort).usePlaintext().intercept(clientInterceptorList).build();
         userProfileServiceStub = UserProfileServiceGrpc.newStub(managedChannel);
         userProfileServiceBlockingStub = UserProfileServiceGrpc.newBlockingStub(managedChannel);
     }

--- a/pom.xml
+++ b/pom.xml
@@ -302,10 +302,10 @@
                         <artifactId>protobuf-maven-plugin</artifactId>
                         <version>${protobuf.maven.plugin}</version>
                         <configuration>
-                            <protocArtifact>com.google.protobuf:protoc:3.0.2:exe:${os.detected.classifier}
+                            <protocArtifact>com.google.protobuf:protoc:${com.google.protobuf.util}:exe:${os.detected.classifier}
                             </protocArtifact>
                             <pluginId>grpc-java</pluginId>
-                            <pluginArtifact>io.grpc:protoc-gen-grpc-java:1.0.1:exe:${os.detected.classifier}
+                            <pluginArtifact>io.grpc:protoc-gen-grpc-java:${io.grpc.version}:exe:${os.detected.classifier}
                             </pluginArtifact>
                         </configuration>
                         <executions>
@@ -400,7 +400,7 @@
         <spring.cloud.stream.version>2.0.0.RELEASE</spring.cloud.stream.version>
         <spring.cloud.slueth.version>2.1.6.RELEASE</spring.cloud.slueth.version>
 
-        <io.grpc.version>1.25.0</io.grpc.version>
+        <io.grpc.version>1.51.0</io.grpc.version>
         <google.common.protos>1.17.0</google.common.protos>
         <io.micrometer.version>1.3.1</io.micrometer.version>
         <brave.version>5.9.1</brave.version>
@@ -419,7 +419,7 @@
 
         <reasteasy.client.version>3.0.14.Final</reasteasy.client.version>
 
-        <com.google.protobuf.util>3.11.3</com.google.protobuf.util>
+        <com.google.protobuf.util>3.21.11</com.google.protobuf.util>
 
         <springfox.swagger.version>2.9.2</springfox.swagger.version>
         <org.wso2.charon>3.3.16</org.wso2.charon>


### PR DESCRIPTION
Porting of the m1 fixes #328 to the baremetal branch. See also #322.

Two additional changes here:

- in sharing-core-impl, removed mysql dependency and added grpc-protobuf dependency. The mysql dependency isn't needed, but it was pulling in a protobuf-java transitive dependency. But that protobuf-java version was an older one not compatible with the newly generated stubs.
- using Maven properties for protoc and grpc versions in the protobuf-maven-plugin configuration