### PR TITLE
Docker build library change and configured NGINX to dynamically resolve Keycloak server 

### DIFF
--- a/custos-rest-proxy/pom.xml
+++ b/custos-rest-proxy/pom.xml
@@ -37,42 +37,47 @@
 
     <build>
         <plugins>
-                    <plugin>
-                        <groupId>org.springframework.boot</groupId>
-                        <artifactId>spring-boot-maven-plugin</artifactId>
-                        <executions>
-                            <execution>
-                                <configuration>
-                                    <mainClass>org.apache.custos.ide.integration.CustosServer</mainClass>
-                                </configuration>
-                            </execution>
-                        </executions>
-                    </plugin>
-                    <plugin>
-                        <groupId>com.spotify</groupId>
-                        <artifactId>dockerfile-maven-plugin</artifactId>
-                        <version>${docker.plugin.version}</version>
-                        <executions>
-                            <execution>
-                                <id>container</id>
-                                <goals>
-                                    <goal>build</goal>
-                                    <goal>push</goal>
-                                </goals>
-                            </execution>
-                        </executions>
+            <plugin>
+                <groupId>org.springframework.boot</groupId>
+                <artifactId>spring-boot-maven-plugin</artifactId>
+                <executions>
+                    <execution>
                         <configuration>
-                            <noCache>true</noCache>
-                            <serverId>docker.io</serverId>
-                            <repository>${docker.image.prefix}/custos-rest-proxy</repository>
-                            <tag>latest</tag>
-                            <useMavenSettingsForAuth>true</useMavenSettingsForAuth>
-                            <buildArgs>
-                                <JAR_FILE>target/${project.build.finalName}.jar</JAR_FILE>
-                            </buildArgs>
-                            <skip>false</skip>
+                            <mainClass>org.apache.custos.ide.integration.CustosServer</mainClass>
                         </configuration>
-                    </plugin>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <groupId>io.fabric8</groupId>
+                <artifactId>docker-maven-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>container</id>
+                        <phase>install</phase>
+                        <goals>
+                            <goal>build</goal>
+                            <goal>push</goal>
+                        </goals>
+                    </execution>
+                </executions>
+                <configuration>
+                    <images>
+                        <image>
+                            <name>${docker.image.prefix}/custos-rest-proxy:latest</name>
+                            <build>
+                                <dockerFileDir>${project.basedir}</dockerFileDir>
+                                <noCache>true</noCache>
+                                <args>
+                                    <JAR_FILE>target/${project.build.finalName}.jar</JAR_FILE>
+                                </args>
+                            </build>
+                        </image>
+                    </images>
+                    <registry>docker.io</registry>
+                    <skip>false</skip>
+                </configuration>
+            </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-enforcer-plugin</artifactId>

--- a/custos-services/custos-core-services-server/pom.xml
+++ b/custos-services/custos-core-services-server/pom.xml
@@ -232,12 +232,12 @@
                 </executions>
             </plugin>
             <plugin>
-                <groupId>com.spotify</groupId>
-                <artifactId>dockerfile-maven-plugin</artifactId>
-                <version>${docker.plugin.version}</version>
+                <groupId>io.fabric8</groupId>
+                <artifactId>docker-maven-plugin</artifactId>
                 <executions>
                     <execution>
                         <id>container</id>
+                        <phase>install</phase>
                         <goals>
                             <goal>build</goal>
                             <goal>push</goal>
@@ -245,14 +245,19 @@
                     </execution>
                 </executions>
                 <configuration>
-                    <noCache>true</noCache>
-                    <serverId>docker.io</serverId>
-                    <repository>${docker.image.prefix}/${project.artifactId}</repository>
-                    <tag>${project.version}</tag>
-                    <useMavenSettingsForAuth>true</useMavenSettingsForAuth>
-                    <buildArgs>
-                        <JAR_FILE>target/${project.build.finalName}.jar</JAR_FILE>
-                    </buildArgs>
+                    <images>
+                        <image>
+                            <name>${docker.image.prefix}/${project.artifactId}:${project.version}</name>
+                            <build>
+                                <dockerFileDir>${project.basedir}</dockerFileDir>
+                                <noCache>true</noCache>
+                                <args>
+                                    <JAR_FILE>target/${project.build.finalName}.jar</JAR_FILE>
+                                </args>
+                            </build>
+                        </image>
+                    </images>
+                    <registry>docker.io</registry>
                     <skip>false</skip>
                 </configuration>
             </plugin>

--- a/custos-services/custos-core-services/agent-profile-core-service/pom.xml
+++ b/custos-services/custos-core-services/agent-profile-core-service/pom.xml
@@ -128,8 +128,8 @@
     <build>
         <plugins>
             <plugin>
-                <groupId>com.spotify</groupId>
-                <artifactId>dockerfile-maven-plugin</artifactId>
+                <groupId>io.fabric8</groupId>
+                <artifactId>docker-maven-plugin</artifactId>
                 <configuration>
                     <skip>false</skip>
                 </configuration>

--- a/custos-services/custos-core-services/cluster-management-core-service/pom.xml
+++ b/custos-services/custos-core-services/cluster-management-core-service/pom.xml
@@ -131,8 +131,8 @@
     <build>
         <plugins>
             <plugin>
-                <groupId>com.spotify</groupId>
-                <artifactId>dockerfile-maven-plugin</artifactId>
+                <groupId>io.fabric8</groupId>
+                <artifactId>docker-maven-plugin</artifactId>
                 <configuration>
                     <skip>false</skip>
                 </configuration>

--- a/custos-services/custos-core-services/credential-store-core-service/pom.xml
+++ b/custos-services/custos-core-services/credential-store-core-service/pom.xml
@@ -161,8 +161,8 @@
     <build>
         <plugins>
             <plugin>
-                <groupId>com.spotify</groupId>
-                <artifactId>dockerfile-maven-plugin</artifactId>
+                <groupId>io.fabric8</groupId>
+                <artifactId>docker-maven-plugin</artifactId>
                 <configuration>
                     <skip>false</skip>
                 </configuration>

--- a/custos-services/custos-core-services/custos-logging/pom.xml
+++ b/custos-services/custos-core-services/custos-logging/pom.xml
@@ -124,8 +124,8 @@
     <build>
         <plugins>
             <plugin>
-                <groupId>com.spotify</groupId>
-                <artifactId>dockerfile-maven-plugin</artifactId>
+                <groupId>io.fabric8</groupId>
+                <artifactId>docker-maven-plugin</artifactId>
                 <configuration>
                     <skip>false</skip>
                 </configuration>

--- a/custos-services/custos-core-services/custos-messaging-core-service/pom.xml
+++ b/custos-services/custos-core-services/custos-messaging-core-service/pom.xml
@@ -146,8 +146,8 @@
     <build>
         <plugins>
             <plugin>
-                <groupId>com.spotify</groupId>
-                <artifactId>dockerfile-maven-plugin</artifactId>
+                <groupId>io.fabric8</groupId>
+                <artifactId>docker-maven-plugin</artifactId>
                 <configuration>
                     <skip>false</skip>
                 </configuration>

--- a/custos-services/custos-core-services/federated-authentication-core-service/pom.xml
+++ b/custos-services/custos-core-services/federated-authentication-core-service/pom.xml
@@ -131,8 +131,8 @@
     <build>
         <plugins>
             <plugin>
-                <groupId>com.spotify</groupId>
-                <artifactId>dockerfile-maven-plugin</artifactId>
+                <groupId>io.fabric8</groupId>
+                <artifactId>docker-maven-plugin</artifactId>
                 <configuration>
                     <skip>false</skip>
                 </configuration>

--- a/custos-services/custos-core-services/iam-admin-core-service/pom.xml
+++ b/custos-services/custos-core-services/iam-admin-core-service/pom.xml
@@ -125,8 +125,8 @@
     <build>
         <plugins>
             <plugin>
-                <groupId>com.spotify</groupId>
-                <artifactId>dockerfile-maven-plugin</artifactId>
+                <groupId>io.fabric8</groupId>
+                <artifactId>docker-maven-plugin</artifactId>
                 <configuration>
                     <skip>false</skip>
                 </configuration>

--- a/custos-services/custos-core-services/identity-core-service/pom.xml
+++ b/custos-services/custos-core-services/identity-core-service/pom.xml
@@ -122,8 +122,8 @@
     <build>
         <plugins>
             <plugin>
-                <groupId>com.spotify</groupId>
-                <artifactId>dockerfile-maven-plugin</artifactId>
+                <groupId>io.fabric8</groupId>
+                <artifactId>docker-maven-plugin</artifactId>
                 <configuration>
                     <skip>false</skip>
                 </configuration>

--- a/custos-services/custos-core-services/resource-secret-core-service/pom.xml
+++ b/custos-services/custos-core-services/resource-secret-core-service/pom.xml
@@ -178,8 +178,8 @@
     <build>
         <plugins>
             <plugin>
-                <groupId>com.spotify</groupId>
-                <artifactId>dockerfile-maven-plugin</artifactId>
+                <groupId>io.fabric8</groupId>
+                <artifactId>docker-maven-plugin</artifactId>
                 <configuration>
                     <skip>false</skip>
                 </configuration>

--- a/custos-services/custos-core-services/sharing-core-service/pom.xml
+++ b/custos-services/custos-core-services/sharing-core-service/pom.xml
@@ -136,8 +136,8 @@
     <build>
         <plugins>
             <plugin>
-                <groupId>com.spotify</groupId>
-                <artifactId>dockerfile-maven-plugin</artifactId>
+                <groupId>io.fabric8</groupId>
+                <artifactId>docker-maven-plugin</artifactId>
                 <configuration>
                     <skip>false</skip>
                 </configuration>

--- a/custos-services/custos-core-services/tenant-profile-core-service/pom.xml
+++ b/custos-services/custos-core-services/tenant-profile-core-service/pom.xml
@@ -141,8 +141,8 @@
     <build>
         <plugins>
             <plugin>
-               <groupId>com.spotify</groupId>
-                <artifactId>dockerfile-maven-plugin</artifactId>
+                <groupId>io.fabric8</groupId>
+                <artifactId>docker-maven-plugin</artifactId>
                 <configuration>
                     <skip>false</skip>
                 </configuration>

--- a/custos-services/custos-core-services/user-profile-core-service/pom.xml
+++ b/custos-services/custos-core-services/user-profile-core-service/pom.xml
@@ -113,8 +113,8 @@
     <build>
         <plugins>
             <plugin>
-                <groupId>com.spotify</groupId>
-                <artifactId>dockerfile-maven-plugin</artifactId>
+                <groupId>io.fabric8</groupId>
+                <artifactId>docker-maven-plugin</artifactId>
                 <configuration>
                     <skip>false</skip>
                 </configuration>

--- a/custos-services/custos-external-services-distributions/custos-grpc-web-proxy/pom.xml
+++ b/custos-services/custos-external-services-distributions/custos-grpc-web-proxy/pom.xml
@@ -33,8 +33,8 @@
     <build>
         <plugins>
             <plugin>
-                <groupId>com.spotify</groupId>
-                <artifactId>dockerfile-maven-plugin</artifactId>
+                <groupId>io.fabric8</groupId>
+                <artifactId>docker-maven-plugin</artifactId>
                 <configuration>
                     <skip>false</skip>
                 </configuration>

--- a/custos-services/custos-external-services-distributions/custos-keycloak/pom.xml
+++ b/custos-services/custos-external-services-distributions/custos-keycloak/pom.xml
@@ -14,8 +14,8 @@
     <build>
         <plugins>
             <plugin>
-                <groupId>com.spotify</groupId>
-                <artifactId>dockerfile-maven-plugin</artifactId>
+                <groupId>io.fabric8</groupId>
+                <artifactId>docker-maven-plugin</artifactId>
                 <configuration>
                     <skip>false</skip>
                 </configuration>

--- a/custos-services/custos-external-services-distributions/custos-keycloak/src/main/resources/standalone-ha.xml
+++ b/custos-services/custos-external-services-distributions/custos-keycloak/src/main/resources/standalone-ha.xml
@@ -133,15 +133,21 @@
                         <password>sa</password>
                     </security>
                 </datasource>
-                <datasource jndi-name="java:jboss/datasources/KeycloakDS" pool-name="KeycloakDS" enabled="true" use-java-context="true" statistics-enabled="${wildfly.datasources.statistics-enabled:${wildfly.statistics-enabled:false}}">
-                    <connection-url>jdbc:h2:${jboss.server.data.dir}/keycloak;AUTO_SERVER=TRUE</connection-url>
-                    <driver>h2</driver>
+                <datasource jndi-name="java:jboss/datasources/KeycloakDS" pool-name="KeycloakDS" enabled="true" use-java-context="true">
+                    <connection-url>jdbc:mysql://host.docker.internal:3306/keycloak</connection-url>
+                    <driver>mysql</driver>
+                    <pool>
+                        <max-pool-size>20</max-pool-size>
+                    </pool>
                     <security>
-                        <user-name>sa</user-name>
-                        <password>sa</password>
+                        <user-name>admin</user-name>
+                        <password>admin</password>
                     </security>
                 </datasource>
                 <drivers>
+                    <driver name="mysql" module="com.mysql">
+                        <xa-datasource-class>com.mysql.cj.jdbc.MysqlXADataSource</xa-datasource-class>
+                    </driver>
                     <driver name="h2" module="com.h2database.h2">
                         <xa-datasource-class>org.h2.jdbcx.JdbcDataSource</xa-datasource-class>
                     </driver>

--- a/custos-services/custos-external-services-distributions/custos-keycloak/src/main/resources/standalone.xml
+++ b/custos-services/custos-external-services-distributions/custos-keycloak/src/main/resources/standalone.xml
@@ -131,15 +131,21 @@
                         <password>sa</password>
                     </security>
                 </datasource>
-                <datasource jndi-name="java:jboss/datasources/KeycloakDS" pool-name="KeycloakDS" enabled="true" use-java-context="true" statistics-enabled="${wildfly.datasources.statistics-enabled:${wildfly.statistics-enabled:false}}">
-                    <connection-url>jdbc:h2:${jboss.server.data.dir}/keycloak;AUTO_SERVER=TRUE</connection-url>
-                    <driver>h2</driver>
+                <datasource jndi-name="java:jboss/datasources/KeycloakDS" pool-name="KeycloakDS" enabled="true" use-java-context="true">
+                    <connection-url>jdbc:mysql://host.docker.internal:3306/keycloak</connection-url>
+                    <driver>mysql</driver>
+                    <pool>
+                        <max-pool-size>20</max-pool-size>
+                    </pool>
                     <security>
-                        <user-name>sa</user-name>
-                        <password>sa</password>
+                        <user-name>admin</user-name>
+                        <password>admin</password>
                     </security>
                 </datasource>
                 <drivers>
+                    <driver name="mysql" module="com.mysql">
+                        <xa-datasource-class>com.mysql.cj.jdbc.MysqlXADataSource</xa-datasource-class>
+                    </driver>
                     <driver name="h2" module="com.h2database.h2">
                         <xa-datasource-class>org.h2.jdbcx.JdbcDataSource</xa-datasource-class>
                     </driver>

--- a/custos-services/custos-integration-services-server/pom.xml
+++ b/custos-services/custos-integration-services-server/pom.xml
@@ -238,12 +238,12 @@
                 </executions>
             </plugin>
             <plugin>
-                <groupId>com.spotify</groupId>
-                <artifactId>dockerfile-maven-plugin</artifactId>
-                <version>${docker.plugin.version}</version>
+                <groupId>io.fabric8</groupId>
+                <artifactId>docker-maven-plugin</artifactId>
                 <executions>
                     <execution>
                         <id>container</id>
+                        <phase>install</phase>
                         <goals>
                             <goal>build</goal>
                             <goal>push</goal>
@@ -251,14 +251,19 @@
                     </execution>
                 </executions>
                 <configuration>
-                    <noCache>true</noCache>
-                    <serverId>docker.io</serverId>
-                    <repository>${docker.image.prefix}/${project.artifactId}</repository>
-                    <tag>${project.version}</tag>
-                    <useMavenSettingsForAuth>true</useMavenSettingsForAuth>
-                    <buildArgs>
-                        <JAR_FILE>target/${project.build.finalName}.jar</JAR_FILE>
-                    </buildArgs>
+                    <images>
+                        <image>
+                            <name>${docker.image.prefix}/${project.artifactId}:${project.version}</name>
+                            <build>
+                                <dockerFileDir>${project.basedir}</dockerFileDir>
+                                <noCache>true</noCache>
+                                <args>
+                                    <JAR_FILE>target/${project.build.finalName}.jar</JAR_FILE>
+                                </args>
+                            </build>
+                        </image>
+                    </images>
+                    <registry>docker.io</registry>
                     <skip>false</skip>
                 </configuration>
             </plugin>

--- a/custos-services/custos-integration-services/agent-management-service/pom.xml
+++ b/custos-services/custos-integration-services/agent-management-service/pom.xml
@@ -112,8 +112,8 @@
     <build>
         <plugins>
             <plugin>
-                <groupId>com.spotify</groupId>
-                <artifactId>dockerfile-maven-plugin</artifactId>
+                <groupId>io.fabric8</groupId>
+                <artifactId>docker-maven-plugin</artifactId>
                 <configuration>
                     <skip>false</skip>
                 </configuration>

--- a/custos-services/custos-integration-services/custos-integration-services-swagger/pom.xml
+++ b/custos-services/custos-integration-services/custos-integration-services-swagger/pom.xml
@@ -78,8 +78,8 @@
     <build>
         <plugins>
             <plugin>
-                <groupId>com.spotify</groupId>
-                <artifactId>dockerfile-maven-plugin</artifactId>
+                <groupId>io.fabric8</groupId>
+                <artifactId>docker-maven-plugin</artifactId>
                 <configuration>
                     <skip>false</skip>
                 </configuration>

--- a/custos-services/custos-integration-services/group-management-service/pom.xml
+++ b/custos-services/custos-integration-services/group-management-service/pom.xml
@@ -113,8 +113,8 @@
     <build>
         <plugins>
             <plugin>
-                <groupId>com.spotify</groupId>
-                <artifactId>dockerfile-maven-plugin</artifactId>
+                <groupId>io.fabric8</groupId>
+                <artifactId>docker-maven-plugin</artifactId>
                 <configuration>
                     <skip>false</skip>
                 </configuration>

--- a/custos-services/custos-integration-services/identity-management-service/pom.xml
+++ b/custos-services/custos-integration-services/identity-management-service/pom.xml
@@ -115,8 +115,8 @@
     <build>
         <plugins>
             <plugin>
-                <groupId>com.spotify</groupId>
-                <artifactId>dockerfile-maven-plugin</artifactId>
+                <groupId>io.fabric8</groupId>
+                <artifactId>docker-maven-plugin</artifactId>
                 <configuration>
                     <skip>false</skip>
                 </configuration>

--- a/custos-services/custos-integration-services/log-management-service/pom.xml
+++ b/custos-services/custos-integration-services/log-management-service/pom.xml
@@ -145,8 +145,8 @@
     <build>
         <plugins>
             <plugin>
-                <groupId>com.spotify</groupId>
-                <artifactId>dockerfile-maven-plugin</artifactId>
+                <groupId>io.fabric8</groupId>
+                <artifactId>docker-maven-plugin</artifactId>
                 <configuration>
                     <skip>false</skip>
                 </configuration>

--- a/custos-services/custos-integration-services/resource-secret-management-service/pom.xml
+++ b/custos-services/custos-integration-services/resource-secret-management-service/pom.xml
@@ -132,8 +132,8 @@
     <build>
         <plugins>
             <plugin>
-                <groupId>com.spotify</groupId>
-                <artifactId>dockerfile-maven-plugin</artifactId>
+                <groupId>io.fabric8</groupId>
+                <artifactId>docker-maven-plugin</artifactId>
                 <configuration>
                     <skip>false</skip>
                 </configuration>

--- a/custos-services/custos-integration-services/scim-service/pom.xml
+++ b/custos-services/custos-integration-services/scim-service/pom.xml
@@ -108,8 +108,8 @@
     <build>
         <plugins>
             <plugin>
-                <groupId>com.spotify</groupId>
-                <artifactId>dockerfile-maven-plugin</artifactId>
+                <groupId>io.fabric8</groupId>
+                <artifactId>docker-maven-plugin</artifactId>
                 <configuration>
                     <skip>false</skip>
                 </configuration>

--- a/custos-services/custos-integration-services/sharing-management-service/pom.xml
+++ b/custos-services/custos-integration-services/sharing-management-service/pom.xml
@@ -123,8 +123,8 @@
     <build>
         <plugins>
             <plugin>
-                <groupId>com.spotify</groupId>
-                <artifactId>dockerfile-maven-plugin</artifactId>
+                <groupId>io.fabric8</groupId>
+                <artifactId>docker-maven-plugin</artifactId>
                 <configuration>
                     <skip>false</skip>
                 </configuration>

--- a/custos-services/custos-integration-services/tenant-management-service/pom.xml
+++ b/custos-services/custos-integration-services/tenant-management-service/pom.xml
@@ -129,8 +129,8 @@
     <build>
         <plugins>
             <plugin>
-                <groupId>com.spotify</groupId>
-                <artifactId>dockerfile-maven-plugin</artifactId>
+                <groupId>io.fabric8</groupId>
+                <artifactId>docker-maven-plugin</artifactId>
                 <configuration>
                     <skip>false</skip>
                 </configuration>

--- a/custos-services/custos-integration-services/user-management-service/pom.xml
+++ b/custos-services/custos-integration-services/user-management-service/pom.xml
@@ -112,8 +112,8 @@
     <build>
         <plugins>
             <plugin>
-                <groupId>com.spotify</groupId>
-                <artifactId>dockerfile-maven-plugin</artifactId>
+                <groupId>io.fabric8</groupId>
+                <artifactId>docker-maven-plugin</artifactId>
                 <configuration>
                     <skip>false</skip>
                 </configuration>

--- a/custos-utilities/ide-integration/Dockerfile
+++ b/custos-utilities/ide-integration/Dockerfile
@@ -1,5 +1,9 @@
 FROM nginx:stable-alpine
-COPY src/main/containers/nginx.conf /etc/nginx/conf.d/default.conf
+COPY src/main/containers/nginx.conf /etc/nginx/conf.d/default.conf.template
 COPY src/main/containers/certificate_mul.pem /etc/nginx/certificate.pem
 COPY src/main/containers/key_mul.pem /etc/nginx/key.pem
+COPY src/main/containers/init/nginx/entrypoint.sh /usr/local/bin/entrypoint.sh
+
+RUN chmod +x /usr/local/bin/entrypoint.sh
+ENTRYPOINT ["/usr/local/bin/entrypoint.sh"]
 EXPOSE 443

--- a/custos-utilities/ide-integration/pom.xml
+++ b/custos-utilities/ide-integration/pom.xml
@@ -133,12 +133,12 @@
                 </executions>
             </plugin>
             <plugin>
-                <groupId>com.spotify</groupId>
-                <artifactId>dockerfile-maven-plugin</artifactId>
-                <version>${docker.plugin.version}</version>
+                <groupId>io.fabric8</groupId>
+                <artifactId>docker-maven-plugin</artifactId>
                 <executions>
                     <execution>
                         <id>container</id>
+                        <phase>install</phase>
                         <goals>
                             <goal>build</goal>
                             <goal>push</goal>
@@ -146,14 +146,19 @@
                     </execution>
                 </executions>
                 <configuration>
-                    <noCache>true</noCache>
-                    <serverId>docker.io</serverId>
-                    <repository>${docker.image.prefix}/keycloak-nginx</repository>
-                    <tag>latest</tag>
-                    <useMavenSettingsForAuth>true</useMavenSettingsForAuth>
-                    <buildArgs>
-                        <JAR_FILE>target/${project.build.finalName}.jar</JAR_FILE>
-                    </buildArgs>
+                    <images>
+                        <image>
+                            <name>${docker.image.prefix}/keycloak-nginx:latest</name>
+                            <build>
+                                <dockerFileDir>${project.basedir}</dockerFileDir>
+                                <noCache>true</noCache>
+                                <args>
+                                    <JAR_FILE>target/${project.build.finalName}.jar</JAR_FILE>
+                                </args>
+                            </build>
+                        </image>
+                    </images>
+                    <registry>docker.io</registry>
                     <skip>false</skip>
                 </configuration>
             </plugin>

--- a/custos-utilities/ide-integration/src/main/containers/docker-compose.yml
+++ b/custos-utilities/ide-integration/src/main/containers/docker-compose.yml
@@ -8,6 +8,14 @@ services:
         KEYCLOAK_USER: admin
         KEYCLOAK_PASSWORD: admin
         PROXY_ADDRESS_FORWARDING: 'true'
+        DB_VENDOR: mysql
+        DB_ADDR: my_sql_local
+        DB_DATABASE: keycloak
+        DB_USER: admin
+        DB_PASSWORD: admin
+      depends_on:
+        - my_sql_local
+
     nginx:
       image: apachecustos/keycloak-nginx:latest
       ports:
@@ -50,7 +58,6 @@ services:
         - "3306:3306"
       environment:
         MYSQL_ROOT_PASSWORD: root
-        MYSQL_DATABASE: core_services_db
         MYSQL_USER: admin
         MYSQL_PASSWORD: admin
         MAX_ALLOWED_PACKET: 1073741824

--- a/custos-utilities/ide-integration/src/main/containers/docker-compose.yml
+++ b/custos-utilities/ide-integration/src/main/containers/docker-compose.yml
@@ -2,6 +2,7 @@ version: "3.3"
 services:
     keycloak:
       image: quay.io/keycloak/keycloak:9.0.2
+      container_name: keycloak
       ports:
         - "8080:8080"
       environment:
@@ -20,6 +21,12 @@ services:
       image: apachecustos/keycloak-nginx:latest
       ports:
         - "443:443"
+      environment:
+        KEYCLOAK_HOST: keycloak
+        NGINX_SERVER_NAME: host.docker.internal
+      depends_on:
+        - keycloak
+
     vault:
       image: vault:1.7.0
       container_name: vault

--- a/custos-utilities/ide-integration/src/main/containers/init/mysql/scripts/bash/init-db.sh
+++ b/custos-utilities/ide-integration/src/main/containers/init/mysql/scripts/bash/init-db.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+
+echo "Creating databases and users..."
+
+mysql -u root -p"$MYSQL_ROOT_PASSWORD" <<-EOSQL
+    CREATE DATABASE IF NOT EXISTS core_services_db;
+    CREATE DATABASE IF NOT EXISTS keycloak;
+    CREATE USER IF NOT EXISTS 'admin'@'%' IDENTIFIED BY 'admin';
+    GRANT ALL PRIVILEGES ON core_services_db.* TO 'admin'@'%';
+    GRANT ALL PRIVILEGES ON keycloak.* TO 'admin'@'%';
+    FLUSH PRIVILEGES;
+EOSQL
+
+echo "Databases and users created"

--- a/custos-utilities/ide-integration/src/main/containers/init/nginx/entrypoint.sh
+++ b/custos-utilities/ide-integration/src/main/containers/init/nginx/entrypoint.sh
@@ -1,0 +1,3 @@
+#!/bin/sh
+envsubst '$KEYCLOAK_HOST,$NGINX_SERVER_NAME' < /etc/nginx/conf.d/default.conf.template > /etc/nginx/conf.d/default.conf
+nginx -g 'daemon off;'

--- a/custos-utilities/ide-integration/src/main/containers/nginx.conf
+++ b/custos-utilities/ide-integration/src/main/containers/nginx.conf
@@ -1,12 +1,12 @@
 upstream keycloak {
-  server host.docker.internal:8080;
+  server ${KEYCLOAK_HOST}:8080;
 }
 
 server {
     listen 443 ssl;
 
     # The host name to respond to
-    server_name        host.docker.internal;
+    server_name        ${NGINX_SERVER_NAME};
     ssl_certificate    /etc/nginx/certificate.pem;
     ssl_certificate_key /etc/nginx/key.pem;
     ssl_prefer_server_ciphers on;

--- a/pom.xml
+++ b/pom.xml
@@ -424,6 +424,15 @@
                 <version>${os.maven.plugin}</version>
             </extension>
         </extensions>
+        <pluginManagement>
+            <plugins>
+                <plugin>
+                    <groupId>io.fabric8</groupId>
+                    <artifactId>docker-maven-plugin</artifactId>
+                    <version>${docker.plugin.version}</version>
+                </plugin>
+            </plugins>
+        </pluginManagement>
 
     </build>
 
@@ -461,7 +470,7 @@
 
         <docker.image.prefix>apachecustos</docker.image.prefix>
         <docker.image.repo>custos</docker.image.repo>
-        <docker.plugin.version>1.4.13</docker.plugin.version>
+        <docker.plugin.version>0.43.4</docker.plugin.version>
 
         <helm.maven.plugin.version>2.8.0</helm.maven.plugin.version>
         <maven.assembly.plugin.version>3.2.0</maven.assembly.plugin.version>


### PR DESCRIPTION
- Updated the Docker build process to use io.fabric8:docker-maven-plugin, as the com.spotify:dockerfile-maven-plugin has ceased development and is incompatible with Apple silicon - https://github.com/spotify/dockerfile-maven/issues/394
- Configured NGINX to dynamically resolve Keycloak host and NGINX server using ENV variables
- Integrated a MySQL DB with Keycloak