### PR TITLE
Added patch functionality for groups

### DIFF
--- a/api/src/main/java/org/apache/custos/api/group/GroupManagementController.java
+++ b/api/src/main/java/org/apache/custos/api/group/GroupManagementController.java
@@ -62,7 +62,6 @@ import org.springframework.web.server.ResponseStatusException;
 import org.springframework.web.servlet.support.ServletUriComponentsBuilder;
 
 import java.net.URI;
-import java.util.List;
 import java.util.Optional;
 
 @RestController
@@ -342,59 +341,7 @@ public class GroupManagementController {
     )
     public ResponseEntity<Group> patchGroup(@PathVariable("groupId") String groupId, @RequestBody Group request, @RequestHeader HttpHeaders headers) {
         AuthClaim authClaim = authorize(headers);
-
-        GroupRequest exGroupReq = GroupRequest.newBuilder()
-                .setTenantId(authClaim.getTenantId())
-                .setClientId(authClaim.getIamAuthId())
-                .setClientSec(authClaim.getIamAuthSecret())
-                .setPerformedBy(authClaim.getPerformedBy() != null ? authClaim.getPerformedBy() : Constants.SYSTEM)
-                .setGroup(request.toBuilder().setId(groupId).build())
-                .build();
-
-        Group exGroup = groupManagementService.findGroup(exGroupReq);
-
-        Group.Builder mergedGroupBuilder = exGroup.toBuilder()
-                .setName(!request.getName().isEmpty() ? request.getName() : exGroup.getName())
-                .setDescription(!request.getDescription().isEmpty() ? request.getDescription() : exGroup.getDescription());
-
-        String REMOVE_ALL_TAG = "custos-remove-all";
-
-        List<String> clientRolesLst = request.getClientRolesList();
-         if (!clientRolesLst.isEmpty()) {
-             mergedGroupBuilder.clearClientRoles();
-             if (!clientRolesLst.get(0).equals(REMOVE_ALL_TAG)) {
-                 mergedGroupBuilder.addAllClientRoles(request.getClientRolesList());
-             }
-        }
-
-        List<String> realmRolesLst = request.getRealmRolesList();
-        if (!realmRolesLst.isEmpty()) {
-            mergedGroupBuilder.clearRealmRoles();
-            if (!realmRolesLst.get(0).equals(REMOVE_ALL_TAG)) {
-                mergedGroupBuilder.addAllRealmRoles(request.getRealmRolesList());
-            }
-        }
-
-        List<GroupAttribute> groupAttributeList = request.getAttributesList();
-        if (!groupAttributeList.isEmpty()) {
-            mergedGroupBuilder.clearAttributes();
-            if (!groupAttributeList.get(0).getKey().equals(REMOVE_ALL_TAG)) {
-                mergedGroupBuilder.addAllAttributes(request.getAttributesList());
-            }
-        }
-
-        Group mergedGroup = mergedGroupBuilder.build();
-
-        GroupRequest updateGroupRequest = GroupRequest.newBuilder()
-                .setTenantId(authClaim.getTenantId())
-                .setClientId(authClaim.getIamAuthId())
-                .setClientSec(authClaim.getIamAuthSecret())
-                .setPerformedBy(authClaim.getPerformedBy() != null ? authClaim.getPerformedBy() : Constants.SYSTEM)
-                .setGroup(mergedGroup.toBuilder().setId(groupId).build())
-                .build();
-
-        Group updatedGroup = groupManagementService.updateGroup(updateGroupRequest);
-
+        Group updatedGroup = groupManagementService.patchGroup(authClaim, groupId, request);
         return ResponseEntity.ok(updatedGroup);
     }
 


### PR DESCRIPTION
With `PATCH`, you only need to pass in the relevant fields you want to change in the body of the request.

**Notes**
- If we don't pass in realm_roles at all (i.e. we don't want to change it), we get it in our handler as an empty list. If we pass in an empty realm_roles (i.e. we want to remove all realm_roles), we get it the SAME way (empty list). This applies for both client_roles, and group attributes. This makes it impossible to detect if users want to keep or remove all list attributes.
- In the current implementation, to remove all realm_roles or client_roles, you pass in ["custos-remove-all"] as the value
- To remove all attributes, pass in [{key: "custos-remove-all", value: "anything....asdfa", id: anything...asdfa}] 