### PR TITLE
AIRAVATA-3972: Fix malformed JSON in Vault local config

### DIFF
--- a/compose/docker-compose.yml
+++ b/compose/docker-compose.yml
@@ -68,7 +68,7 @@ services:
       VAULT_ADDR: http://0.0.0.0:8201
       VAULT_API_ADDR: http://127.0.0.1:8200
       VAULT_CLUSTER_ADDR: http://127.0.0.1:8201
-      VAULT_LOCAL_CONFIG: '{"listener": [{"tcp":{"address": "0.0.0.0:8201","tls_disable":"1"}}], "default_lease_ttl": "168h", "max_lease_ttl": "720h"}, "ui": true}'
+      VAULT_LOCAL_CONFIG: '{"listener": [{"tcp":{"address": "0.0.0.0:8201","tls_disable":"1"}}], "default_lease_ttl": "168h", "max_lease_ttl": "720h", "ui": true}'
     cap_add:
       - IPC_LOCK
     volumes:


### PR DESCRIPTION
## Summary

- One-line fix for a misplaced closing brace in `VAULT_LOCAL_CONFIG` in `compose/docker-compose.yml` that caused the `"ui": true` property to fall outside the JSON object, silently preventing the Vault UI from being enabled during local development.

**JIRA:** [AIRAVATA-3972](https://issues.apache.org/jira/browse/AIRAVATA-3972)

## Details

**Before (invalid JSON):**
```
'{"listener": [...], "max_lease_ttl": "720h"}, "ui": true}'
```

**After (valid JSON):**
```
'{"listener": [...], "max_lease_ttl": "720h", "ui": true}'
```

## Test plan

- [ ] Parse the `VAULT_LOCAL_CONFIG` value with any JSON validator — confirms it is now valid JSON
- [ ] Run `docker compose up` from the `compose/` directory and verify the Vault UI is accessible at `http://localhost:8200/ui`