### PR TITLE
AMIE Decoding service Audit logs and Bug fixes

### DIFF
--- a/allocations/access-ci-service/loadtest/README.md
+++ b/allocations/access-ci-service/loadtest/README.md
@@ -1,0 +1,43 @@
+# AMIE Traffic Simulation
+
+k6 load test that generates AMIE test scenarios at varying rates to simulate real-world traffic patterns.
+
+## Prerequisites
+
+```bash
+# macOS
+brew install k6
+```
+
+## Usage
+
+```bash
+# Basic run (resets test server automatically)
+AMIE_API_KEY=<your-key> k6 run amie-traffic.js
+
+# With Prometheus metrics export
+AMIE_API_KEY=<key> k6 run --out experimental-prometheus-rw=http://localhost:9090/api/v1/write amie-traffic.js
+
+# Override AMIE endpoint
+AMIE_BASE_URL=https://custom-endpoint AMIE_SITE=MySite AMIE_API_KEY=<key> k6 run amie-traffic.js
+```
+
+## Traffic Profile (~20 minutes)
+
+```
+VUs
+ 8 |                                              *
+ 5 |         ***************                     * *
+ 2 |       **               *****   ************     **
+ 1 | ******                      ***                   ****
+   |──────────────────────────────────────────────────────── time
+     warm  ramp    peak     cool  steady  quiet  spike  recovery
+```
+
+## Environment Variables
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `AMIE_API_KEY` | (required) | AMIE API authentication key |
+| `AMIE_BASE_URL` | `https://a3mdev.xsede.org/amie-api-test` | AMIE test API base URL |
+| `AMIE_SITE` | `GaTech` | Site code for AMIE |

--- a/allocations/access-ci-service/loadtest/amie-traffic.js
+++ b/allocations/access-ci-service/loadtest/amie-traffic.js
@@ -1,0 +1,118 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import http from 'k6/http';
+import {check, sleep} from 'k6';
+import {Counter} from 'k6/metrics';
+import {randomIntBetween} from 'https://jslib.k6.io/k6-utils/1.4.0/index.js';
+
+const BASE_URL = __ENV.AMIE_BASE_URL || 'https://a3mdev.xsede.org/amie-api-test';
+const SITE = __ENV.AMIE_SITE || 'GaTech';
+const API_KEY = __ENV.AMIE_API_KEY;
+
+if (!API_KEY) {
+    throw new Error('AMIE_API_KEY environment variable is required');
+}
+
+const scenariosCreated = new Counter('amie_scenarios_created');
+
+const HEADERS = {
+    'XA-SITE': SITE,
+    'XA-API-KEY': API_KEY,
+};
+
+// Mock server uses mixed type to get both success and failure packets.
+// Standard test scenarios with the real AMIE test server.
+const USE_MOCK = (BASE_URL.includes('localhost') || BASE_URL.includes('127.0.0.1'));
+
+// Weighted scenario types for real AMIE (cumulative thresholds)
+const REAL_SCENARIO_TYPES = [
+    {type: 'request_project_reactivate', weight: 0.30},
+    {type: 'request_account_reactivate', weight: 0.60},
+    {type: 'request_person_merge', weight: 0.80},
+    {type: 'request_user_modify', weight: 1.00},
+];
+
+const MOCK_SCENARIO_TYPES = [
+    {type: 'mixed', weight: 0.50},
+    {type: 'success_only', weight: 0.70},
+    {type: 'failures_only', weight: 0.85},
+    {type: 'heavy', weight: 1.00},
+];
+
+const SCENARIO_TYPES = USE_MOCK ? MOCK_SCENARIO_TYPES : REAL_SCENARIO_TYPES;
+
+function pickScenarioType() {
+    const r = Math.random();
+    for (const s of SCENARIO_TYPES) {
+        if (r <= s.weight) return s.type;
+    }
+    return SCENARIO_TYPES[SCENARIO_TYPES.length - 1].type;
+}
+
+// Traffic stages: warm-up → ramp → peak → cool down → steady → quiet → spike → recovery
+export const options = {
+    stages: [
+        {duration: '1m', target: 1},   // warm-up
+        {duration: '2m', target: 5},   // ramp up
+        {duration: '5m', target: 5},   // peak
+        {duration: '2m', target: 2},   // cool down
+        {duration: '5m', target: 2},   // steady
+        {duration: '3m', target: 1},   // quiet
+        {duration: '30s', target: 8},   // spike
+        {duration: '2m', target: 1},   // recovery
+    ],
+    thresholds: {
+        http_req_failed: ['rate<0.05'],
+        http_req_duration: ['p(95)<5000'],
+    },
+};
+
+export function setup() {
+    // Reset AMIE test server before the run
+    const res = http.post(`${BASE_URL}/test/${SITE}/reset`, null, {headers: HEADERS});
+    check(res, {'reset succeeded': (r) => r.status === 200});
+    console.log(`AMIE test server reset for site ${SITE}`);
+    sleep(2);
+}
+
+export default function () {
+    const scenarioType = pickScenarioType();
+    const url = `${BASE_URL}/test/${SITE}/scenarios?type=${scenarioType}`;
+
+    const res = http.post(url, null, {
+        headers: HEADERS,
+        tags: {scenario_type: scenarioType},
+    });
+
+    check(res, {
+        'scenario created (200)': (r) => r.status === 200,
+    });
+
+    if (res.status === 200) {
+        scenariosCreated.add(1, {type: scenarioType});
+    }
+
+    // Randomized pause between scenario creation (5-15s)
+    sleep(randomIntBetween(5, 15));
+}
+
+export function teardown() {
+    console.log('Load test complete. Check Grafana for processing metrics.');
+}

--- a/allocations/access-ci-service/loadtest/mock-amie-server.py
+++ b/allocations/access-ci-service/loadtest/mock-amie-server.py
@@ -1,0 +1,336 @@
+#!/usr/bin/env python3
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements. See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership. The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License. You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied. See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+# Mock AMIE server for testing the ACCESS CI service with both
+# success and failure scenarios. Simulates the AMIE API endpoints
+# that the service polls.
+#
+# Usage:
+#   python3 mock-amie-server.py
+#
+# Then point the service at: access.amie.base-url=http://localhost:8180
+
+import json
+import random
+import time
+import uuid
+from flask import Flask, jsonify, request
+from pathlib import Path
+
+app = Flask(__name__)
+
+pending_packets = []
+replied_packets = {}
+packet_counter = 900000  # starting ID
+stats = {"created": 0, "fetched": 0, "replied": 0}
+
+SCENARIOS_DIR = Path(__file__).parent / "scenarios"
+
+
+def next_id():
+    global packet_counter
+    packet_counter += 1
+    return packet_counter
+
+
+def make_packet(packet_type, body, transaction_id=None):
+    rec_id = next_id()
+    return {
+        "header": {
+            "packet_rec_id": rec_id,
+            "transaction_id": transaction_id or f"TXN-{uuid.uuid4().hex[:8]}",
+            "packet_type": packet_type,
+            "type_id": 1,
+            "local_site_name": "MockSite",
+            "remote_site_name": "TGCDB",
+            "packet_state": "in_progress",
+            "packet_timestamp": time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime()),
+        },
+        "type": packet_type,
+        "body": body,
+    }
+
+
+# Scenario generators
+
+def gen_valid_project_create():
+    gid = str(random.randint(100000, 999999))
+    grant = f"TST{random.randint(100000, 999999)}"
+    return make_packet("request_project_create", {
+        "GrantNumber": grant,
+        "PfosNumber": f"PFOS-{grant}",
+        "ProjectTitle": f"Mock project {grant}",
+        "PiGlobalID": gid,
+        "PiFirstName": random.choice(["Alice", "Bob", "Carol", "Dave", "Eve"]),
+        "PiLastName": random.choice(["Smith", "Johnson", "Williams", "Brown", "Jones"]),
+        "PiEmail": f"user{gid}@example.edu",
+        "PiOrganization": "Mock University",
+        "PiOrgCode": "MOCK",
+        "NsfStatusCode": "AC",
+        "PiDnList": [f"/C=US/O=Mock University/CN=User {gid}"],
+        "ServiceUnitsAllocated": str(random.randint(1000, 50000)),
+        "StartDate": "2026-01-01",
+        "EndDate": "2026-12-31",
+        "ResourceList": "mock-cluster.example.edu",
+    })
+
+
+def gen_valid_account_create():
+    gid = str(random.randint(100000, 999999))
+    return make_packet("request_account_create", {
+        "ProjectID": f"PRJ-MOCK{random.randint(1000, 9999)}",
+        "GrantNumber": f"TST{random.randint(100000, 999999)}",
+        "UserGlobalID": gid,
+        "UserFirstName": random.choice(["Frank", "Grace", "Heidi", "Ivan", "Judy"]),
+        "UserLastName": random.choice(["Davis", "Garcia", "Rodriguez", "Wilson", "Martinez"]),
+        "UserEmail": f"user{gid}@example.edu",
+        "UserOrganization": "Mock Institute",
+        "UserOrgCode": "MI",
+        "NsfStatusCode": "GR",
+        "UserDnList": [f"/C=US/O=Mock Institute/CN=User {gid}"],
+        "ResourceList": "mock-cluster.example.edu",
+    })
+
+
+def gen_valid_user_modify():
+    gid = str(random.randint(100000, 999999))
+    return make_packet("request_user_modify", {
+        "PersonID": f"person-mock-{uuid.uuid4().hex[:8]}",
+        "ActionType": "replace",
+        "UserFirstName": "Updated",
+        "UserLastName": "Name",
+        "UserEmail": f"updated{gid}@example.edu",
+        "UserOrganization": "Updated University",
+    })
+
+
+def gen_inform_transaction_complete():
+    return make_packet("inform_transaction_complete", {
+        "StatusCode": "Success",
+        "StatusMessage": "OK",
+        "DetailCode": "1",
+    })
+
+
+# Failure scenarios
+
+def gen_missing_global_id():
+    """request_account_create with no UserGlobalID — will cause IllegalArgumentException."""
+    return make_packet("request_account_create", {
+        "ProjectID": f"PRJ-FAIL{random.randint(1000, 9999)}",
+        "GrantNumber": f"FAIL{random.randint(100000, 999999)}",
+        # UserGlobalID MISSING — required field
+        "UserFirstName": "NoGlobalID",
+        "UserLastName": "User",
+        "UserEmail": "noglobal@example.edu",
+        "ResourceList": "mock-cluster.example.edu",
+    })
+
+
+def gen_missing_grant_number():
+    """request_project_create with no GrantNumber — will cause IllegalArgumentException."""
+    return make_packet("request_project_create", {
+        # GrantNumber MISSING — required field
+        "PiGlobalID": str(random.randint(100000, 999999)),
+        "PiFirstName": "NoGrant",
+        "PiLastName": "User",
+        "PiEmail": "nogrant@example.edu",
+        "NsfStatusCode": "AC",
+        "ResourceList": "mock-cluster.example.edu",
+    })
+
+
+def gen_missing_email():
+    """request_project_create with no PiEmail — known optional field."""
+    gid = str(random.randint(100000, 999999))
+    return make_packet("request_project_create", {
+        "GrantNumber": f"NOEMAIL{random.randint(100000, 999999)}",
+        "PiGlobalID": gid,
+        "PiFirstName": "NoEmail",
+        "PiLastName": "Person",
+        # PiEmail MISSING — optional per protocol, but we need it
+        "PiOrganization": "No Email University",
+        "NsfStatusCode": "AC",
+        "PiDnList": [],
+        "ResourceList": "mock-cluster.example.edu",
+    })
+
+
+def gen_missing_pi_name():
+    """request_project_create with no PiFirstName — will cause IllegalArgumentException."""
+    return make_packet("request_project_create", {
+        "GrantNumber": f"NONAME{random.randint(100000, 999999)}",
+        "PiGlobalID": str(random.randint(100000, 999999)),
+        # PiFirstName MISSING — asserted as required
+        "PiLastName": "OnlyLast",
+        "PiEmail": "noname@example.edu",
+        "NsfStatusCode": "AC",
+        "ResourceList": "mock-cluster.example.edu",
+    })
+
+
+def gen_invalid_person_modify():
+    """request_user_modify for a person that doesn't exist in the DB."""
+    return make_packet("request_user_modify", {
+        "PersonID": "nonexistent-person-id-12345",
+        "ActionType": "replace",
+        "UserFirstName": "Ghost",
+        "UserLastName": "User",
+        "UserEmail": "ghost@example.edu",
+    })
+
+
+def gen_unknown_packet_type():
+    """Packet with an unrecognized type — should hit NoOpHandler."""
+    return make_packet("request_something_unknown", {
+        "SomeField": "SomeValue",
+    })
+
+
+def gen_empty_body():
+    """Packet with an empty body — should cause NPE or validation failure."""
+    return make_packet("request_project_create", {})
+
+
+# Scenario mix
+
+SUCCESS_GENERATORS = [
+    (gen_valid_project_create, 3),
+    (gen_valid_account_create, 3),
+    (gen_valid_user_modify, 1),
+    (gen_inform_transaction_complete, 2),
+]
+
+FAILURE_GENERATORS = [
+    (gen_missing_global_id, 2),
+    (gen_missing_grant_number, 1),
+    (gen_missing_email, 2),
+    (gen_missing_pi_name, 1),
+    (gen_invalid_person_modify, 2),
+    (gen_unknown_packet_type, 1),
+    (gen_empty_body, 1),
+]
+
+
+def generate_batch(success_count=6, failure_count=4):
+    """Generate a mixed batch of success and failure packets."""
+    packets = []
+
+    success_pool = []
+    for gen, weight in SUCCESS_GENERATORS:
+        success_pool.extend([gen] * weight)
+
+    failure_pool = []
+    for gen, weight in FAILURE_GENERATORS:
+        failure_pool.extend([gen] * weight)
+
+    for _ in range(success_count):
+        gen = random.choice(success_pool)
+        packets.append(gen())
+
+    for _ in range(failure_count):
+        gen = random.choice(failure_pool)
+        packets.append(gen())
+
+    random.shuffle(packets)
+    return packets
+
+
+# API endpoints
+
+@app.route("/packets/<site>", methods=["GET"])
+def get_packets(site):
+    """Return pending packets (mimics AMIE API poll).
+    Returns a JSON array at the top level, matching the format
+    that AmieClient.parsePacketsFromResponse() expects."""
+    if not pending_packets:
+        return jsonify([])
+
+    batch = list(pending_packets)
+    pending_packets.clear()
+    stats["fetched"] += len(batch)
+
+    app.logger.info(f"Serving {len(batch)} packets to site {site}")
+    return jsonify(batch)
+
+
+@app.route("/packets/<site>/<int:packet_rec_id>/reply", methods=["POST"])
+def reply_to_packet(site, packet_rec_id):
+    """Accept a reply from the service."""
+    replied_packets[packet_rec_id] = request.get_json(silent=True)
+    stats["replied"] += 1
+    return jsonify({"message": "Reply accepted"}), 200
+
+
+@app.route("/test/<site>/reset", methods=["POST"])
+def reset(site):
+    """Reset all state."""
+    pending_packets.clear()
+    replied_packets.clear()
+    stats["created"] = 0
+    stats["fetched"] = 0
+    stats["replied"] = 0
+    app.logger.info(f"Reset state for site {site}")
+    return jsonify({"message": f"Reset site data for {site}", "result": None})
+
+
+@app.route("/test/<site>/scenarios", methods=["POST"])
+def create_scenario(site):
+    """Generate a batch of mixed success/failure scenarios."""
+    scenario_type = request.args.get("type", "mixed")
+
+    if scenario_type == "mixed":
+        packets = generate_batch(success_count=6, failure_count=4)
+    elif scenario_type == "failures_only":
+        packets = generate_batch(success_count=0, failure_count=8)
+    elif scenario_type == "success_only":
+        packets = generate_batch(success_count=8, failure_count=0)
+    elif scenario_type == "heavy":
+        packets = generate_batch(success_count=15, failure_count=10)
+    else:
+        packets = generate_batch(success_count=3, failure_count=2)
+
+    pending_packets.extend(packets)
+    stats["created"] += len(packets)
+
+    app.logger.info(f"Created {len(packets)} packets ({scenario_type}) for site {site}")
+    return jsonify({"message": "Test scenario initiated", "result": None})
+
+
+@app.route("/stats", methods=["GET"])
+def get_stats():
+    """Stats endpoint for debugging."""
+    return jsonify({
+        "pending": len(pending_packets),
+        "replied": len(replied_packets),
+        "stats": stats,
+    })
+
+
+if __name__ == "__main__":
+    print("Mock AMIE Server starting on http://localhost:8180")
+    print("Point your service at: access.amie.base-url=http://localhost:8180")
+    print("")
+    print("Scenario types:")
+    print("  POST /test/{site}/scenarios?type=mixed          — 6 success + 4 failure")
+    print("  POST /test/{site}/scenarios?type=failures_only  — 8 failures")
+    print("  POST /test/{site}/scenarios?type=success_only   — 8 successes")
+    print("  POST /test/{site}/scenarios?type=heavy          — 15 success + 10 failure")
+    print("")
+    app.run(host="0.0.0.0", port=8180, debug=False)

--- a/allocations/access-ci-service/pom.xml
+++ b/allocations/access-ci-service/pom.xml
@@ -77,7 +77,19 @@
             <groupId>com.google.protobuf</groupId>
             <artifactId>protobuf-java</artifactId>
         </dependency>
-        
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-actuator</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.micrometer</groupId>
+            <artifactId>micrometer-registry-prometheus</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>net.logstash.logback</groupId>
+            <artifactId>logstash-logback-encoder</artifactId>
+        </dependency>
+
         <!-- Test dependencies -->
         <dependency>
             <groupId>org.springframework.boot</groupId>

--- a/allocations/access-ci-service/src/main/java/org/apache/custos/access/ci/service/AmiePoller.java
+++ b/allocations/access-ci-service/src/main/java/org/apache/custos/access/ci/service/AmiePoller.java
@@ -20,6 +20,7 @@ package org.apache.custos.access.ci.service;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import org.apache.custos.access.ci.service.client.amie.AmieClient;
+import org.apache.custos.access.ci.service.metrics.AmieMetrics;
 import org.apache.custos.access.ci.service.model.amie.PacketEntity;
 import org.apache.custos.access.ci.service.model.amie.PacketStatus;
 import org.apache.custos.access.ci.service.model.amie.ProcessingEventEntity;
@@ -30,6 +31,7 @@ import org.apache.custos.access.ci.service.repo.amie.ProcessingEventRepository;
 import org.apache.custos.access.ci.service.util.ProtoUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.slf4j.MDC;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Component;
@@ -51,11 +53,14 @@ public class AmiePoller {
     private final AmieClient client;
     private final PacketRepository packetRepo;
     private final ProcessingEventRepository eventRepo;
+    private final AmieMetrics amieMetrics;
 
-    public AmiePoller(AmieClient client, PacketRepository packetRepo, ProcessingEventRepository eventRepo) {
+    public AmiePoller(AmieClient client, PacketRepository packetRepo, ProcessingEventRepository eventRepo,
+                      AmieMetrics amieMetrics) {
         this.client = client;
         this.packetRepo = packetRepo;
         this.eventRepo = eventRepo;
+        this.amieMetrics = amieMetrics;
     }
 
 
@@ -71,12 +76,24 @@ public class AmiePoller {
         }
 
         LOGGER.info("Found {} packets to process.", packets.size());
+        amieMetrics.recordPollerFetch(packets.size());
+
         for (JsonNode packetNode : packets) {
+            String packetType = packetNode.path("type").asText(null);
+            long amiePacketRecId = packetNode.at("/header/packet_rec_id").asLong(-1);
+
+            MDC.put("amieId", String.valueOf(amiePacketRecId));
+            if (packetType != null) {
+                MDC.put("packetType", packetType);
+            }
             try {
                 processIndividualPacket(packetNode);
             } catch (Exception e) {
                 // If a malformed packet is found
                 LOGGER.error("An unexpected error occurred while processing a packet. Raw packet: {}", packetNode.toString(), e);
+            } finally {
+                MDC.remove("amieId");
+                MDC.remove("packetType");
             }
         }
     }
@@ -108,6 +125,8 @@ public class AmiePoller {
                     newPacket.setRawJson(packetNode.toString());
                     newPacket.setReceivedAt(Instant.now());
                     packetRepo.save(newPacket);
+
+                    amieMetrics.recordPacketReceived(packetType);
 
                     ProcessingEventEntity decodeEvent = new ProcessingEventEntity();
                     decodeEvent.setPacket(newPacket);

--- a/allocations/access-ci-service/src/main/java/org/apache/custos/access/ci/service/handler/amie/DataAccountCreateHandler.java
+++ b/allocations/access-ci-service/src/main/java/org/apache/custos/access/ci/service/handler/amie/DataAccountCreateHandler.java
@@ -20,7 +20,9 @@ package org.apache.custos.access.ci.service.handler.amie;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import org.apache.custos.access.ci.service.client.amie.AmieClient;
+import org.apache.custos.access.ci.service.model.amie.AuditAction;
 import org.apache.custos.access.ci.service.model.amie.PacketEntity;
+import org.apache.custos.access.ci.service.service.AuditService;
 import org.apache.custos.access.ci.service.service.PersonService;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -42,10 +44,12 @@ public class DataAccountCreateHandler implements PacketHandler {
 
     private final AmieClient amieClient;
     private final PersonService personService;
+    private final AuditService auditService;
 
-    public DataAccountCreateHandler(AmieClient amieClient, PersonService personService) {
+    public DataAccountCreateHandler(AmieClient amieClient, PersonService personService, AuditService auditService) {
         this.amieClient = amieClient;
         this.personService = personService;
+        this.auditService = auditService;
     }
 
     @Override
@@ -54,7 +58,7 @@ public class DataAccountCreateHandler implements PacketHandler {
     }
 
     @Override
-    public void handle(JsonNode packetJson, PacketEntity packetEntity) {
+    public void handle(JsonNode packetJson, PacketEntity packetEntity, String eventId) {
         LOGGER.info("Starting 'data_account_create' handler for packet amie_id [{}].", packetEntity.getAmieId());
 
         JsonNode body = packetJson.path("body");
@@ -69,10 +73,16 @@ public class DataAccountCreateHandler implements PacketHandler {
         if (dnList.isArray() && !dnList.isEmpty()) {
             LOGGER.info("Persisting DnList for person [{}] from data_account_create.", personId);
             personService.persistDnsForPerson(personId, dnList);
+            auditService.log(packetEntity.getId(), eventId, AuditAction.PERSIST_DNS,
+                    "person", personId,
+                    "Persisted " + dnList.size() + " DN(s) for person " + personId + " from data_account_create");
         }
 
         // Send the 'inform_transaction_complete' reply to close the transaction.
         sendSuccessReply(packetEntity.getAmieId());
+        auditService.log(packetEntity.getId(), eventId, AuditAction.REPLY_SENT,
+                "packet", packetEntity.getId(),
+                "Sent inform_transaction_complete reply for data_account_create");
     }
 
     private void sendSuccessReply(long packetRecId) {

--- a/allocations/access-ci-service/src/main/java/org/apache/custos/access/ci/service/handler/amie/DataAccountCreateHandler.java
+++ b/allocations/access-ci-service/src/main/java/org/apache/custos/access/ci/service/handler/amie/DataAccountCreateHandler.java
@@ -21,6 +21,7 @@ package org.apache.custos.access.ci.service.handler.amie;
 import com.fasterxml.jackson.databind.JsonNode;
 import org.apache.custos.access.ci.service.client.amie.AmieClient;
 import org.apache.custos.access.ci.service.model.amie.PacketEntity;
+import org.apache.custos.access.ci.service.service.PersonService;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Component;
@@ -40,9 +41,11 @@ public class DataAccountCreateHandler implements PacketHandler {
     private static final Logger LOGGER = LoggerFactory.getLogger(DataAccountCreateHandler.class);
 
     private final AmieClient amieClient;
+    private final PersonService personService;
 
-    public DataAccountCreateHandler(AmieClient amieClient) {
+    public DataAccountCreateHandler(AmieClient amieClient, PersonService personService) {
         this.amieClient = amieClient;
+        this.personService = personService;
     }
 
     @Override
@@ -63,12 +66,9 @@ public class DataAccountCreateHandler implements PacketHandler {
         Assert.hasText(personId, "'PersonID' must not be empty.");
         LOGGER.info("Packet validated. ProjectID: [{}], PersonID: [{}].", projectId, personId);
 
-
-        // TODO - perform the business logic
-        //  - find the user's record by 'personId' (localID) and update the distinguished names (dnList)
         if (dnList.isArray() && !dnList.isEmpty()) {
-            LOGGER.info("Received DnList for user [{}]. In a real implementation, this would be saved to the user's profile.", personId);
-            // TODO userService.updateUserDnList(personId, dnList);
+            LOGGER.info("Persisting DnList for person [{}] from data_account_create.", personId);
+            personService.persistDnsForPerson(personId, dnList);
         }
 
         // Send the 'inform_transaction_complete' reply to close the transaction.

--- a/allocations/access-ci-service/src/main/java/org/apache/custos/access/ci/service/handler/amie/DataProjectCreateHandler.java
+++ b/allocations/access-ci-service/src/main/java/org/apache/custos/access/ci/service/handler/amie/DataProjectCreateHandler.java
@@ -21,6 +21,7 @@ package org.apache.custos.access.ci.service.handler.amie;
 import com.fasterxml.jackson.databind.JsonNode;
 import org.apache.custos.access.ci.service.client.amie.AmieClient;
 import org.apache.custos.access.ci.service.model.amie.PacketEntity;
+import org.apache.custos.access.ci.service.service.PersonService;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Component;
@@ -38,9 +39,11 @@ public class DataProjectCreateHandler implements PacketHandler {
     private static final Logger LOGGER = LoggerFactory.getLogger(DataProjectCreateHandler.class);
 
     private final AmieClient amieClient;
+    private final PersonService personService;
 
-    public DataProjectCreateHandler(AmieClient amieClient) {
+    public DataProjectCreateHandler(AmieClient amieClient, PersonService personService) {
         this.amieClient = amieClient;
+        this.personService = personService;
     }
 
     @Override
@@ -61,11 +64,11 @@ public class DataProjectCreateHandler implements PacketHandler {
         Assert.hasText(personId, "'PersonID' must not be empty.");
         LOGGER.info("Packet validated. ProjectID: [{}], PersonID: [{}].", projectId, personId);
 
-        // TODO update the local DB with the dnList against to the user's profile
         if (dnList.isArray() && !dnList.isEmpty()) {
-            LOGGER.info("Received DnList for user [{}].", personId);
-            // TODO - userService.updateUserDnList(personId, dnList);
+            LOGGER.info("Persisting DnList for person [{}] from data_project_create.", personId);
+            personService.persistDnsForPerson(personId, dnList);
         }
+
         sendSuccessReply(packetEntity.getAmieId());
     }
 

--- a/allocations/access-ci-service/src/main/java/org/apache/custos/access/ci/service/handler/amie/DataProjectCreateHandler.java
+++ b/allocations/access-ci-service/src/main/java/org/apache/custos/access/ci/service/handler/amie/DataProjectCreateHandler.java
@@ -20,7 +20,9 @@ package org.apache.custos.access.ci.service.handler.amie;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import org.apache.custos.access.ci.service.client.amie.AmieClient;
+import org.apache.custos.access.ci.service.model.amie.AuditAction;
 import org.apache.custos.access.ci.service.model.amie.PacketEntity;
+import org.apache.custos.access.ci.service.service.AuditService;
 import org.apache.custos.access.ci.service.service.PersonService;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -40,10 +42,12 @@ public class DataProjectCreateHandler implements PacketHandler {
 
     private final AmieClient amieClient;
     private final PersonService personService;
+    private final AuditService auditService;
 
-    public DataProjectCreateHandler(AmieClient amieClient, PersonService personService) {
+    public DataProjectCreateHandler(AmieClient amieClient, PersonService personService, AuditService auditService) {
         this.amieClient = amieClient;
         this.personService = personService;
+        this.auditService = auditService;
     }
 
     @Override
@@ -52,7 +56,7 @@ public class DataProjectCreateHandler implements PacketHandler {
     }
 
     @Override
-    public void handle(JsonNode packetJson, PacketEntity packetEntity) {
+    public void handle(JsonNode packetJson, PacketEntity packetEntity, String eventId) {
         LOGGER.info("Starting 'data_project_create' handler for packet amie_id [{}].", packetEntity.getAmieId());
 
         JsonNode body = packetJson.path("body");
@@ -67,9 +71,15 @@ public class DataProjectCreateHandler implements PacketHandler {
         if (dnList.isArray() && !dnList.isEmpty()) {
             LOGGER.info("Persisting DnList for person [{}] from data_project_create.", personId);
             personService.persistDnsForPerson(personId, dnList);
+            auditService.log(packetEntity.getId(), eventId, AuditAction.PERSIST_DNS,
+                    "person", personId,
+                    "Persisted " + dnList.size() + " DN(s) for person " + personId + " from data_project_create");
         }
 
         sendSuccessReply(packetEntity.getAmieId());
+        auditService.log(packetEntity.getId(), eventId, AuditAction.REPLY_SENT,
+                "packet", packetEntity.getId(),
+                "Sent inform_transaction_complete reply for data_project_create");
     }
 
     private void sendSuccessReply(long packetRecId) {

--- a/allocations/access-ci-service/src/main/java/org/apache/custos/access/ci/service/handler/amie/InformTransactionCompleteHandler.java
+++ b/allocations/access-ci-service/src/main/java/org/apache/custos/access/ci/service/handler/amie/InformTransactionCompleteHandler.java
@@ -19,7 +19,9 @@
 package org.apache.custos.access.ci.service.handler.amie;
 
 import com.fasterxml.jackson.databind.JsonNode;
+import org.apache.custos.access.ci.service.model.amie.AuditAction;
 import org.apache.custos.access.ci.service.model.amie.PacketEntity;
+import org.apache.custos.access.ci.service.service.AuditService;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Component;
@@ -34,13 +36,19 @@ public class InformTransactionCompleteHandler implements PacketHandler {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(InformTransactionCompleteHandler.class);
 
+    private final AuditService auditService;
+
+    public InformTransactionCompleteHandler(AuditService auditService) {
+        this.auditService = auditService;
+    }
+
     @Override
     public String supportsType() {
         return "inform_transaction_complete";
     }
 
     @Override
-    public void handle(JsonNode packetJson, PacketEntity packetEntity) {
+    public void handle(JsonNode packetJson, PacketEntity packetEntity, String eventId) {
         // This packet is purely informational and completes the transaction
         JsonNode body = packetJson.path("body");
         String statusCode = body.path("StatusCode").asText("Unknown");
@@ -48,5 +56,9 @@ public class InformTransactionCompleteHandler implements PacketHandler {
 
         LOGGER.info("Received 'inform_transaction_complete' for packet amie_id [{}]. Status: [{}], Message: [{}]. Transaction is now closed.",
                 packetEntity.getAmieId(), statusCode, message);
+
+        auditService.log(packetEntity.getId(), eventId, AuditAction.TRANSACTION_COMPLETE,
+                "packet", packetEntity.getId(),
+                "Transaction complete received. Status: " + statusCode);
     }
 }

--- a/allocations/access-ci-service/src/main/java/org/apache/custos/access/ci/service/handler/amie/NoOpHandler.java
+++ b/allocations/access-ci-service/src/main/java/org/apache/custos/access/ci/service/handler/amie/NoOpHandler.java
@@ -33,7 +33,7 @@ public class NoOpHandler implements PacketHandler {
     private static final Logger LOGGER = LoggerFactory.getLogger(NoOpHandler.class);
 
     @Override
-    public void handle(JsonNode packetJson, PacketEntity packetEntity) {
+    public void handle(JsonNode packetJson, PacketEntity packetEntity, String eventId) {
         LOGGER.info("NoOpHandler executed for packet with amie_packet_rec_id [{}] and type [{}]. No action taken.", packetEntity.getAmieId(), packetEntity.getType());
         // No operations
     }

--- a/allocations/access-ci-service/src/main/java/org/apache/custos/access/ci/service/handler/amie/PacketHandler.java
+++ b/allocations/access-ci-service/src/main/java/org/apache/custos/access/ci/service/handler/amie/PacketHandler.java
@@ -28,9 +28,10 @@ public interface PacketHandler {
      *
      * @param packetJson   The raw packet content
      * @param packetEntity The entity for the packet
+     * @param eventId      The processing event ID for audit logging
      * @throws Exception if processing fails
      */
-    void handle(JsonNode packetJson, PacketEntity packetEntity) throws Exception;
+    void handle(JsonNode packetJson, PacketEntity packetEntity, String eventId) throws Exception;
 
     /**
      * Define which packet type this handler is responsible for.

--- a/allocations/access-ci-service/src/main/java/org/apache/custos/access/ci/service/handler/amie/PacketRouter.java
+++ b/allocations/access-ci-service/src/main/java/org/apache/custos/access/ci/service/handler/amie/PacketRouter.java
@@ -20,6 +20,7 @@ package org.apache.custos.access.ci.service.handler.amie;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import org.apache.custos.access.ci.service.model.amie.PacketEntity;
+import org.slf4j.MDC;
 import org.springframework.stereotype.Component;
 
 import java.util.List;
@@ -43,11 +44,13 @@ public class PacketRouter {
      *
      * @param packetJson   The raw packet content
      * @param packetEntity The Packet entity
+     * @param eventId      The processing event ID for audit logging
      * @throws Exception if the handler logic fails
      */
-    public void route(JsonNode packetJson, PacketEntity packetEntity) throws Exception {
+    public void route(JsonNode packetJson, PacketEntity packetEntity, String eventId) throws Exception {
         PacketHandler handler = findHandlerFor(packetEntity.getType());
-        handler.handle(packetJson, packetEntity);
+        MDC.put("handler", handler.getClass().getSimpleName());
+        handler.handle(packetJson, packetEntity, eventId);
     }
 
     private PacketHandler findHandlerFor(String packetType) {

--- a/allocations/access-ci-service/src/main/java/org/apache/custos/access/ci/service/handler/amie/RequestAccountCreateHandler.java
+++ b/allocations/access-ci-service/src/main/java/org/apache/custos/access/ci/service/handler/amie/RequestAccountCreateHandler.java
@@ -22,7 +22,9 @@ import com.fasterxml.jackson.databind.JsonNode;
 import org.apache.custos.access.ci.service.client.amie.AmieClient;
 import org.apache.custos.access.ci.service.model.ClusterAccountEntity;
 import org.apache.custos.access.ci.service.model.PersonEntity;
+import org.apache.custos.access.ci.service.model.amie.AuditAction;
 import org.apache.custos.access.ci.service.model.amie.PacketEntity;
+import org.apache.custos.access.ci.service.service.AuditService;
 import org.apache.custos.access.ci.service.service.PersonService;
 import org.apache.custos.access.ci.service.service.ProjectMembershipService;
 import org.apache.custos.access.ci.service.service.ProjectService;
@@ -52,15 +54,17 @@ public class RequestAccountCreateHandler implements PacketHandler {
     private final UserAccountService userAccountService;
     private final ProjectService projectService;
     private final ProjectMembershipService membershipService;
+    private final AuditService auditService;
 
     public RequestAccountCreateHandler(AmieClient amieClient, PersonService personService,
                                        UserAccountService userAccountService, ProjectService projectService,
-                                       ProjectMembershipService membershipService) {
+                                       ProjectMembershipService membershipService, AuditService auditService) {
         this.amieClient = amieClient;
         this.personService = personService;
         this.userAccountService = userAccountService;
         this.projectService = projectService;
         this.membershipService = membershipService;
+        this.auditService = auditService;
     }
 
     @Override
@@ -69,7 +73,7 @@ public class RequestAccountCreateHandler implements PacketHandler {
     }
 
     @Override
-    public void handle(JsonNode packetJson, PacketEntity packetEntity) throws Exception {
+    public void handle(JsonNode packetJson, PacketEntity packetEntity, String eventId) throws Exception {
         LOGGER.info("Starting 'request_account_create' handler for packet amie_id [{}].", packetEntity.getAmieId());
 
         JsonNode body = packetJson.path("body");
@@ -84,17 +88,30 @@ public class RequestAccountCreateHandler implements PacketHandler {
 
         PersonEntity person = personService.findOrCreatePersonFromPacket(body);
         LOGGER.info("Ensured person record exists with local ID [{}].", person.getId());
+        auditService.log(packetEntity.getId(), eventId, AuditAction.CREATE_PERSON,
+                "person", person.getId(),
+                "Created person '" + person.getFirstName() + " " + person.getLastName() + "'");
 
         ClusterAccountEntity clusterAccount = userAccountService.provisionClusterAccount(person);
         LOGGER.info("Provisioned new cluster account [{}] with username [{}].", clusterAccount.getId(), clusterAccount.getUsername());
+        auditService.log(packetEntity.getId(), eventId, AuditAction.CREATE_ACCOUNT,
+                "account", clusterAccount.getId(),
+                "Created cluster account '" + clusterAccount.getUsername() + "' for person " + person.getId());
 
         projectService.createOrFindProject(projectId, grantNumber);
         LOGGER.info("Ensured project [{}] exists.", projectId);
 
         membershipService.createMembership(projectId, clusterAccount.getId(), "USER");
         LOGGER.info("Created 'USER' membership for cluster account [{}] on project [{}].", clusterAccount.getId(), projectId);
+        auditService.log(packetEntity.getId(), eventId, AuditAction.CREATE_MEMBERSHIP,
+                "membership", clusterAccount.getId(),
+                "Created USER membership for account " + clusterAccount.getId() + " on project " + projectId);
 
         sendSuccessReply(packetEntity.getAmieId(), body, person.getId(), clusterAccount.getUsername());
+        auditService.log(packetEntity.getId(), eventId, AuditAction.REPLY_SENT,
+                "packet", packetEntity.getId(),
+                "Sent notify_account_create reply for project " + projectId);
+
         LOGGER.info("Successfully completed 'request_account_create' handler and sent reply for packet amie_id [{}].", packetEntity.getAmieId());
     }
 

--- a/allocations/access-ci-service/src/main/java/org/apache/custos/access/ci/service/handler/amie/RequestAccountInactivateHandler.java
+++ b/allocations/access-ci-service/src/main/java/org/apache/custos/access/ci/service/handler/amie/RequestAccountInactivateHandler.java
@@ -20,7 +20,9 @@ package org.apache.custos.access.ci.service.handler.amie;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import org.apache.custos.access.ci.service.client.amie.AmieClient;
+import org.apache.custos.access.ci.service.model.amie.AuditAction;
 import org.apache.custos.access.ci.service.model.amie.PacketEntity;
+import org.apache.custos.access.ci.service.service.AuditService;
 import org.apache.custos.access.ci.service.service.ProjectMembershipService;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -45,10 +47,13 @@ public class RequestAccountInactivateHandler implements PacketHandler {
 
     private final AmieClient amieClient;
     private final ProjectMembershipService membershipService;
+    private final AuditService auditService;
 
-    public RequestAccountInactivateHandler(AmieClient amieClient, ProjectMembershipService membershipService) {
+    public RequestAccountInactivateHandler(AmieClient amieClient, ProjectMembershipService membershipService,
+                                           AuditService auditService) {
         this.amieClient = amieClient;
         this.membershipService = membershipService;
+        this.auditService = auditService;
     }
 
     @Override
@@ -57,7 +62,7 @@ public class RequestAccountInactivateHandler implements PacketHandler {
     }
 
     @Override
-    public void handle(JsonNode packetJson, PacketEntity packetEntity) {
+    public void handle(JsonNode packetJson, PacketEntity packetEntity, String eventId) {
         LOGGER.info("Starting 'request_account_inactivate' handler for packet amie_id [{}].", packetEntity.getAmieId());
 
         JsonNode body = packetJson.path("body");
@@ -69,8 +74,14 @@ public class RequestAccountInactivateHandler implements PacketHandler {
         LOGGER.info("Packet validated. Inactivating account for user [{}] on project [{}].", personId, projectId);
 
         membershipService.inactivateMembershipsByPersonAndProject(projectId, personId);
+        auditService.log(packetEntity.getId(), eventId, AuditAction.INACTIVATE_MEMBERSHIP,
+                "person", personId,
+                "Inactivated membership for person " + personId + " on project " + projectId);
 
         sendSuccessReply(packetEntity.getAmieId(), body);
+        auditService.log(packetEntity.getId(), eventId, AuditAction.REPLY_SENT,
+                "packet", packetEntity.getId(),
+                "Sent notify_account_inactivate reply for person " + personId + " on project " + projectId);
 
         LOGGER.info("Successfully completed 'request_account_inactivate' handler and sent reply for packet amie_id [{}].", packetEntity.getAmieId());
     }

--- a/allocations/access-ci-service/src/main/java/org/apache/custos/access/ci/service/handler/amie/RequestAccountReactivateHandler.java
+++ b/allocations/access-ci-service/src/main/java/org/apache/custos/access/ci/service/handler/amie/RequestAccountReactivateHandler.java
@@ -19,7 +19,9 @@ package org.apache.custos.access.ci.service.handler.amie;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import org.apache.custos.access.ci.service.client.amie.AmieClient;
+import org.apache.custos.access.ci.service.model.amie.AuditAction;
 import org.apache.custos.access.ci.service.model.amie.PacketEntity;
+import org.apache.custos.access.ci.service.service.AuditService;
 import org.apache.custos.access.ci.service.service.ProjectMembershipService;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -44,10 +46,13 @@ public class RequestAccountReactivateHandler implements PacketHandler {
 
     private final AmieClient amieClient;
     private final ProjectMembershipService membershipService;
+    private final AuditService auditService;
 
-    public RequestAccountReactivateHandler(AmieClient amieClient, ProjectMembershipService membershipService) {
+    public RequestAccountReactivateHandler(AmieClient amieClient, ProjectMembershipService membershipService,
+                                           AuditService auditService) {
         this.amieClient = amieClient;
         this.membershipService = membershipService;
+        this.auditService = auditService;
     }
 
     @Override
@@ -56,7 +61,7 @@ public class RequestAccountReactivateHandler implements PacketHandler {
     }
 
     @Override
-    public void handle(JsonNode packetJson, PacketEntity packetEntity) {
+    public void handle(JsonNode packetJson, PacketEntity packetEntity, String eventId) {
         LOGGER.info("Starting 'request_account_reactivate' handler for packet amie_id [{}].", packetEntity.getAmieId());
 
         JsonNode body = packetJson.path("body");
@@ -68,8 +73,14 @@ public class RequestAccountReactivateHandler implements PacketHandler {
         LOGGER.info("Packet validated. Reactivating account for user [{}] on project [{}].", personId, projectId);
 
         membershipService.reactivateMembershipsByPersonAndProject(projectId, personId);
+        auditService.log(packetEntity.getId(), eventId, AuditAction.REACTIVATE_MEMBERSHIP,
+                "person", personId,
+                "Reactivated membership for person " + personId + " on project " + projectId);
 
         sendSuccessReply(packetEntity.getAmieId(), body);
+        auditService.log(packetEntity.getId(), eventId, AuditAction.REPLY_SENT,
+                "packet", packetEntity.getId(),
+                "Sent notify_account_reactivate reply for person " + personId + " on project " + projectId);
 
         LOGGER.info("Successfully completed 'request_account_reactivate' handler and sent reply for packet amie_id [{}].", packetEntity.getAmieId());
     }

--- a/allocations/access-ci-service/src/main/java/org/apache/custos/access/ci/service/handler/amie/RequestPersonMergeHandler.java
+++ b/allocations/access-ci-service/src/main/java/org/apache/custos/access/ci/service/handler/amie/RequestPersonMergeHandler.java
@@ -20,7 +20,9 @@ package org.apache.custos.access.ci.service.handler.amie;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import org.apache.custos.access.ci.service.client.amie.AmieClient;
+import org.apache.custos.access.ci.service.model.amie.AuditAction;
 import org.apache.custos.access.ci.service.model.amie.PacketEntity;
+import org.apache.custos.access.ci.service.service.AuditService;
 import org.apache.custos.access.ci.service.service.PersonService;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -47,10 +49,12 @@ public class RequestPersonMergeHandler implements PacketHandler {
 
     private final AmieClient amieClient;
     private final PersonService personService;
+    private final AuditService auditService;
 
-    public RequestPersonMergeHandler(AmieClient amieClient, PersonService personService) {
+    public RequestPersonMergeHandler(AmieClient amieClient, PersonService personService, AuditService auditService) {
         this.amieClient = amieClient;
         this.personService = personService;
+        this.auditService = auditService;
     }
 
     @Override
@@ -60,7 +64,7 @@ public class RequestPersonMergeHandler implements PacketHandler {
 
     @Override
     @Transactional
-    public void handle(JsonNode packetJson, PacketEntity packetEntity) {
+    public void handle(JsonNode packetJson, PacketEntity packetEntity, String eventId) {
         LOGGER.info("Starting 'request_person_merge' handler for packet amie_id [{}].", packetEntity.getAmieId());
 
         JsonNode body = packetJson.path("body");
@@ -75,8 +79,14 @@ public class RequestPersonMergeHandler implements PacketHandler {
                 retiringPersonLocalId, retiringPersonGlobalId, survivingPersonLocalId, survivingPersonGlobalId);
 
         personService.mergePersons(survivingPersonLocalId, retiringPersonLocalId);
+        auditService.log(packetEntity.getId(), eventId, AuditAction.MERGE_PERSONS,
+                "person", survivingPersonLocalId,
+                "Merged person " + retiringPersonLocalId + " into " + survivingPersonLocalId);
 
         sendSuccessReply(packetEntity.getAmieId());
+        auditService.log(packetEntity.getId(), eventId, AuditAction.REPLY_SENT,
+                "packet", packetEntity.getId(),
+                "Sent inform_transaction_complete reply for person merge");
     }
 
     private void sendSuccessReply(long packetRecId) {

--- a/allocations/access-ci-service/src/main/java/org/apache/custos/access/ci/service/handler/amie/RequestProjectCreateHandler.java
+++ b/allocations/access-ci-service/src/main/java/org/apache/custos/access/ci/service/handler/amie/RequestProjectCreateHandler.java
@@ -24,7 +24,9 @@ import org.apache.custos.access.ci.service.client.amie.AmieClient;
 import org.apache.custos.access.ci.service.model.ClusterAccountEntity;
 import org.apache.custos.access.ci.service.model.PersonEntity;
 import org.apache.custos.access.ci.service.model.ProjectEntity;
+import org.apache.custos.access.ci.service.model.amie.AuditAction;
 import org.apache.custos.access.ci.service.model.amie.PacketEntity;
+import org.apache.custos.access.ci.service.service.AuditService;
 import org.apache.custos.access.ci.service.service.PersonService;
 import org.apache.custos.access.ci.service.service.ProjectMembershipService;
 import org.apache.custos.access.ci.service.service.ProjectService;
@@ -50,14 +52,17 @@ public class RequestProjectCreateHandler implements PacketHandler {
     private final UserAccountService userAccountService;
     private final ProjectService projectService;
     private final ProjectMembershipService membershipService;
+    private final AuditService auditService;
 
     public RequestProjectCreateHandler(AmieClient amieClient, PersonService personService, UserAccountService userAccountService,
-                                       ProjectService projectService, ProjectMembershipService membershipService) {
+                                       ProjectService projectService, ProjectMembershipService membershipService,
+                                       AuditService auditService) {
         this.amieClient = amieClient;
         this.personService = personService;
         this.userAccountService = userAccountService;
         this.projectService = projectService;
         this.membershipService = membershipService;
+        this.auditService = auditService;
     }
 
     @Override
@@ -66,7 +71,7 @@ public class RequestProjectCreateHandler implements PacketHandler {
     }
 
     @Override
-    public void handle(JsonNode packetJson, PacketEntity packetEntity) throws Exception {
+    public void handle(JsonNode packetJson, PacketEntity packetEntity, String eventId) throws Exception {
         LOGGER.info("Starting 'request_project_create' handler for packet amie_id [{}].", packetEntity.getAmieId());
 
         // TODO - refactor the sanity checks into Packet Router (if all the packets follow the same style)
@@ -96,18 +101,34 @@ public class RequestProjectCreateHandler implements PacketHandler {
         ObjectNode piAsUserNode = createPiAsUserNode(body);
         PersonEntity piPerson = personService.findOrCreatePersonFromPacket(piAsUserNode);
         LOGGER.info("PI person record exists with local ID [{}].", piPerson.getId());
+        auditService.log(packetEntity.getId(), eventId, AuditAction.CREATE_PERSON,
+                "person", piPerson.getId(),
+                "Created person '" + piPerson.getFirstName() + " " + piPerson.getLastName() + "'");
 
         ClusterAccountEntity piClusterAccount = userAccountService.provisionClusterAccount(piPerson);
         LOGGER.info("Provisioned cluster account for PI [{}] with username [{}].", piPerson.getId(), piClusterAccount.getUsername());
+        auditService.log(packetEntity.getId(), eventId, AuditAction.CREATE_ACCOUNT,
+                "account", piClusterAccount.getId(),
+                "Created cluster account '" + piClusterAccount.getUsername() + "' for person " + piPerson.getId());
 
         String localProjectId = "PRJ-" + grantNumber;
         ProjectEntity project = projectService.createOrFindProject(localProjectId, grantNumber);
         LOGGER.info("Project [{}] exists.", project.getId());
+        auditService.log(packetEntity.getId(), eventId, AuditAction.CREATE_PROJECT,
+                "project", project.getId(),
+                "Created project '" + project.getId() + "' for grant " + grantNumber);
 
         membershipService.createMembership(project.getId(), piClusterAccount.getId(), "PI");
         LOGGER.info("Created 'PI' membership for cluster account [{}] on project [{}].", piClusterAccount.getId(), project.getId());
+        auditService.log(packetEntity.getId(), eventId, AuditAction.CREATE_MEMBERSHIP,
+                "membership", piClusterAccount.getId(),
+                "Created PI membership for account " + piClusterAccount.getId() + " on project " + project.getId());
 
         sendSuccessReply(packetEntity.getAmieId(), body, project.getId(), piPerson.getId(), piClusterAccount.getUsername());
+        auditService.log(packetEntity.getId(), eventId, AuditAction.REPLY_SENT,
+                "packet", packetEntity.getId(),
+                "Sent notify_project_create reply for grant " + grantNumber);
+
         LOGGER.info("Successfully completed 'request_project_create' handler and sent reply for packet amie_id [{}].", packetEntity.getAmieId());
     }
 

--- a/allocations/access-ci-service/src/main/java/org/apache/custos/access/ci/service/handler/amie/RequestProjectInactivateHandler.java
+++ b/allocations/access-ci-service/src/main/java/org/apache/custos/access/ci/service/handler/amie/RequestProjectInactivateHandler.java
@@ -20,7 +20,9 @@ package org.apache.custos.access.ci.service.handler.amie;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import org.apache.custos.access.ci.service.client.amie.AmieClient;
+import org.apache.custos.access.ci.service.model.amie.AuditAction;
 import org.apache.custos.access.ci.service.model.amie.PacketEntity;
+import org.apache.custos.access.ci.service.service.AuditService;
 import org.apache.custos.access.ci.service.service.ProjectMembershipService;
 import org.apache.custos.access.ci.service.service.ProjectService;
 import org.slf4j.Logger;
@@ -42,11 +44,14 @@ public class RequestProjectInactivateHandler implements PacketHandler {
     private final AmieClient amieClient;
     private final ProjectService projectService;
     private final ProjectMembershipService membershipService;
+    private final AuditService auditService;
 
-    public RequestProjectInactivateHandler(AmieClient amieClient, ProjectService projectService, ProjectMembershipService membershipService) {
+    public RequestProjectInactivateHandler(AmieClient amieClient, ProjectService projectService,
+                                           ProjectMembershipService membershipService, AuditService auditService) {
         this.amieClient = amieClient;
         this.projectService = projectService;
         this.membershipService = membershipService;
+        this.auditService = auditService;
     }
 
     @Override
@@ -55,7 +60,7 @@ public class RequestProjectInactivateHandler implements PacketHandler {
     }
 
     @Override
-    public void handle(JsonNode packetJson, PacketEntity packetEntity) {
+    public void handle(JsonNode packetJson, PacketEntity packetEntity, String eventId) {
         LOGGER.info("Starting 'request_project_inactivate' handler for packet amie_id [{}].", packetEntity.getAmieId());
 
         JsonNode body = packetJson.path("body");
@@ -65,10 +70,21 @@ public class RequestProjectInactivateHandler implements PacketHandler {
         LOGGER.info("Packet validated. ProjectID to inactivate: [{}].", projectId);
 
         projectService.inactivateProject(projectId);
+        LOGGER.info("Inactivated project [{}].", projectId);
+        auditService.log(packetEntity.getId(), eventId, AuditAction.INACTIVATE_PROJECT,
+                "project", projectId,
+                "Inactivated project " + projectId);
+
         membershipService.inactivateAllMembershipsForProject(projectId);
-        LOGGER.info("Inactivated project [{}] and all associated memberships.", projectId);
+        LOGGER.info("Inactivated all memberships for project [{}].", projectId);
+        auditService.log(packetEntity.getId(), eventId, AuditAction.INACTIVATE_MEMBERSHIP,
+                "project", projectId,
+                "Inactivated all memberships for project " + projectId);
 
         sendSuccessReply(packetEntity.getAmieId(), body);
+        auditService.log(packetEntity.getId(), eventId, AuditAction.REPLY_SENT,
+                "packet", packetEntity.getId(),
+                "Sent notify_project_inactivate reply for project " + projectId);
 
         LOGGER.info("Successfully completed 'request_project_inactivate' handler and sent reply for packet amie_id [{}].", packetEntity.getAmieId());
     }

--- a/allocations/access-ci-service/src/main/java/org/apache/custos/access/ci/service/handler/amie/RequestProjectReactivateHandler.java
+++ b/allocations/access-ci-service/src/main/java/org/apache/custos/access/ci/service/handler/amie/RequestProjectReactivateHandler.java
@@ -20,7 +20,9 @@ package org.apache.custos.access.ci.service.handler.amie;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import org.apache.custos.access.ci.service.client.amie.AmieClient;
+import org.apache.custos.access.ci.service.model.amie.AuditAction;
 import org.apache.custos.access.ci.service.model.amie.PacketEntity;
+import org.apache.custos.access.ci.service.service.AuditService;
 import org.apache.custos.access.ci.service.service.ProjectMembershipService;
 import org.apache.custos.access.ci.service.service.ProjectService;
 import org.slf4j.Logger;
@@ -45,11 +47,14 @@ public class RequestProjectReactivateHandler implements PacketHandler {
     private final AmieClient amieClient;
     private final ProjectService projectService;
     private final ProjectMembershipService membershipService;
+    private final AuditService auditService;
 
-    public RequestProjectReactivateHandler(AmieClient amieClient, ProjectService projectService, ProjectMembershipService membershipService) {
+    public RequestProjectReactivateHandler(AmieClient amieClient, ProjectService projectService,
+                                           ProjectMembershipService membershipService, AuditService auditService) {
         this.amieClient = amieClient;
         this.projectService = projectService;
         this.membershipService = membershipService;
+        this.auditService = auditService;
     }
 
     @Override
@@ -59,7 +64,7 @@ public class RequestProjectReactivateHandler implements PacketHandler {
 
 
     @Override
-    public void handle(JsonNode packetJson, PacketEntity packetEntity) {
+    public void handle(JsonNode packetJson, PacketEntity packetEntity, String eventId) {
         LOGGER.info("Starting 'request_project_reactivate' handler for packet amie_id [{}].", packetEntity.getAmieId());
 
         JsonNode body = packetJson.path("body");
@@ -69,10 +74,21 @@ public class RequestProjectReactivateHandler implements PacketHandler {
         LOGGER.info("Packet validated. ProjectID to reactivate: [{}].", projectId);
 
         projectService.reactivateProject(projectId);
+        LOGGER.info("Reactivated project [{}].", projectId);
+        auditService.log(packetEntity.getId(), eventId, AuditAction.REACTIVATE_PROJECT,
+                "project", projectId,
+                "Reactivated project " + projectId);
+
         membershipService.reactivatePiMembership(projectId);
-        LOGGER.info("Reactivated project [{}] and PI membership(s).", projectId);
+        LOGGER.info("Reactivated PI membership(s) for project [{}].", projectId);
+        auditService.log(packetEntity.getId(), eventId, AuditAction.REACTIVATE_MEMBERSHIP,
+                "project", projectId,
+                "Reactivated PI membership(s) for project " + projectId);
 
         sendSuccessReply(packetEntity.getAmieId(), body);
+        auditService.log(packetEntity.getId(), eventId, AuditAction.REPLY_SENT,
+                "packet", packetEntity.getId(),
+                "Sent notify_project_reactivate reply for project " + projectId);
 
         LOGGER.info("Successfully completed 'request_project_reactivate' handler and sent reply for packet amie_id [{}].", packetEntity.getAmieId());
     }

--- a/allocations/access-ci-service/src/main/java/org/apache/custos/access/ci/service/handler/amie/RequestUserModifyHandler.java
+++ b/allocations/access-ci-service/src/main/java/org/apache/custos/access/ci/service/handler/amie/RequestUserModifyHandler.java
@@ -20,7 +20,9 @@ package org.apache.custos.access.ci.service.handler.amie;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import org.apache.custos.access.ci.service.client.amie.AmieClient;
+import org.apache.custos.access.ci.service.model.amie.AuditAction;
 import org.apache.custos.access.ci.service.model.amie.PacketEntity;
+import org.apache.custos.access.ci.service.service.AuditService;
 import org.apache.custos.access.ci.service.service.PersonService;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -40,10 +42,12 @@ public class RequestUserModifyHandler implements PacketHandler {
 
     private final AmieClient amieClient;
     private final PersonService personService;
+    private final AuditService auditService;
 
-    public RequestUserModifyHandler(AmieClient amieClient, PersonService personService) {
+    public RequestUserModifyHandler(AmieClient amieClient, PersonService personService, AuditService auditService) {
         this.amieClient = amieClient;
         this.personService = personService;
+        this.auditService = auditService;
     }
 
     @Override
@@ -52,7 +56,7 @@ public class RequestUserModifyHandler implements PacketHandler {
     }
 
     @Override
-    public void handle(JsonNode packetJson, PacketEntity packetEntity) throws Exception {
+    public void handle(JsonNode packetJson, PacketEntity packetEntity, String eventId) throws Exception {
         LOGGER.info("Starting 'request_user_modify' handler for packet amie_id [{}].", packetEntity.getAmieId());
 
         JsonNode body = packetJson.path("body");
@@ -62,15 +66,24 @@ public class RequestUserModifyHandler implements PacketHandler {
         switch (actionType.toLowerCase()) {
             case "replace":
                 personService.replaceFromModifyPacket(body);
+                auditService.log(packetEntity.getId(), eventId, AuditAction.UPDATE_PERSON,
+                        "person", body.path("UserGlobalID").asText(null),
+                        "Updated person via request_user_modify (replace)");
                 break;
             case "delete":
                 personService.deleteFromModifyPacket(body);
+                auditService.log(packetEntity.getId(), eventId, AuditAction.DELETE_PERSON,
+                        "person", body.path("UserGlobalID").asText(null),
+                        "Deleted person via request_user_modify (delete)");
                 break;
             default:
                 throw new IllegalArgumentException("Unsupported ActionType: " + actionType);
         }
 
         sendSuccessReply(packetEntity.getAmieId());
+        auditService.log(packetEntity.getId(), eventId, AuditAction.REPLY_SENT,
+                "packet", packetEntity.getId(),
+                "Sent inform_transaction_complete reply for request_user_modify (" + actionType + ")");
     }
 
     private void sendSuccessReply(long packetRecId) {

--- a/allocations/access-ci-service/src/main/java/org/apache/custos/access/ci/service/metrics/AmieHealthIndicator.java
+++ b/allocations/access-ci-service/src/main/java/org/apache/custos/access/ci/service/metrics/AmieHealthIndicator.java
@@ -1,0 +1,78 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ */
+package org.apache.custos.access.ci.service.metrics;
+
+import org.apache.custos.access.ci.service.config.AmieProperties;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.boot.actuate.health.AbstractHealthIndicator;
+import org.springframework.boot.actuate.health.Health;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Component;
+import org.springframework.web.client.RestClientException;
+import org.springframework.web.client.RestTemplate;
+
+/**
+ * Actuator health indicator for the upstream AMIE API.
+ *
+ * <p>Performs an HTTP GET to the configured AMIE base URL and reports
+ * {@link Health#up()} when the endpoint responds, or {@link Health#down()} when
+ * a network or HTTP error occurs.
+ */
+@Component
+public class AmieHealthIndicator extends AbstractHealthIndicator {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(AmieHealthIndicator.class);
+
+    private final AmieProperties amieProperties;
+    private final RestTemplate restTemplate;
+
+    public AmieHealthIndicator(AmieProperties amieProperties,
+                               @Qualifier("amieRestTemplate") RestTemplate restTemplate) {
+        super("AMIE API health check failed");
+        this.amieProperties = amieProperties;
+        this.restTemplate = restTemplate;
+    }
+
+    @Override
+    protected void doHealthCheck(Health.Builder builder) {
+        String baseUrl = amieProperties.getBaseUrl();
+        String siteCode = amieProperties.getSiteCode();
+        try {
+            ResponseEntity<String> response = restTemplate.getForEntity(baseUrl, String.class);
+            if (response.getStatusCode().is2xxSuccessful() || response.getStatusCode().is3xxRedirection()) {
+                builder.up()
+                        .withDetail("url", baseUrl)
+                        .withDetail("siteCode", siteCode)
+                        .withDetail("httpStatus", response.getStatusCode().value());
+            } else {
+                builder.down()
+                        .withDetail("url", baseUrl)
+                        .withDetail("siteCode", siteCode)
+                        .withDetail("httpStatus", response.getStatusCode().value());
+            }
+        } catch (RestClientException ex) {
+            LOGGER.warn("AMIE API health check failed for URL [{}]: {}", baseUrl, ex.getMessage());
+            builder.down(ex)
+                    .withDetail("url", baseUrl)
+                    .withDetail("siteCode", siteCode);
+        }
+    }
+}

--- a/allocations/access-ci-service/src/main/java/org/apache/custos/access/ci/service/metrics/AmieMetrics.java
+++ b/allocations/access-ci-service/src/main/java/org/apache/custos/access/ci/service/metrics/AmieMetrics.java
@@ -1,0 +1,124 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ */
+package org.apache.custos.access.ci.service.metrics;
+
+import io.micrometer.core.instrument.Counter;
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.Timer;
+import org.springframework.stereotype.Component;
+
+/**
+ * Metrics for the AMIE packet processing pipeline.
+ *
+ * <p>All metric names follow the Prometheus naming convention:
+ * {@code amie_<subsystem>_<measurement>_<unit>}.
+ */
+@Component
+public class AmieMetrics {
+
+    private static final String PACKETS_RECEIVED_TOTAL = "amie_packets_received_total";
+    private static final String PACKETS_PROCESSED_TOTAL = "amie_packets_processed_total";
+    private static final String EVENTS_RETRY_TOTAL = "amie_events_retry_total";
+    private static final String PROCESSING_DURATION_SECONDS = "amie_packet_processing_duration_seconds";
+    private static final String POLLER_PACKETS_FETCHED = "amie_poller_packets_fetched";
+
+    private static final String TAG_TYPE = "type";
+    private static final String TAG_OUTCOME = "outcome";
+    private static final String TAG_HANDLER = "handler";
+
+    private final MeterRegistry meterRegistry;
+
+    public AmieMetrics(MeterRegistry meterRegistry) {
+        this.meterRegistry = meterRegistry;
+    }
+
+    /**
+     * Increments the counter tracking raw packets received from the AMIE API, tagged by packet type.
+     *
+     * @param packetType the AMIE packet type (e.g., "request_project_create")
+     */
+    public void recordPacketReceived(String packetType) {
+        Counter.builder(PACKETS_RECEIVED_TOTAL)
+                .tag(TAG_TYPE, packetType)
+                .description("Total number of AMIE packets received from the API")
+                .register(meterRegistry)
+                .increment();
+    }
+
+    /**
+     * Increments the counter tracking processed packets, tagged by packet type and outcome.
+     *
+     * @param packetType the AMIE packet type (e.g., "request_project_create")
+     * @param outcome    the processing outcome (e.g., "success", "failure")
+     */
+    public void recordPacketProcessed(String packetType, String outcome) {
+        Counter.builder(PACKETS_PROCESSED_TOTAL)
+                .tag(TAG_TYPE, packetType)
+                .tag(TAG_OUTCOME, outcome)
+                .description("Total number of AMIE packets that completed processing")
+                .register(meterRegistry)
+                .increment();
+    }
+
+    /**
+     * Increments the counter tracking event retry attempts.
+     */
+    public void recordRetry() {
+        Counter.builder(EVENTS_RETRY_TOTAL)
+                .description("Total number of AMIE processing event retry attempts")
+                .register(meterRegistry)
+                .increment();
+    }
+
+    /**
+     * Starts a timer sample for measuring packet processing duration.
+     *
+     * @return a {@link Timer.Sample} that must be stopped via {@link #stopProcessingTimer}
+     */
+    public Timer.Sample startProcessingTimer() {
+        return Timer.start(meterRegistry);
+    }
+
+    /**
+     * Stops a previously started timer sample and records the duration against the
+     * {@code amie_packet_processing_duration_seconds} timer, tagged by handler type.
+     *
+     * @param sample      the sample returned by {@link #startProcessingTimer()}
+     * @param handlerType the name of the handler that processed the packet
+     */
+    public void stopProcessingTimer(Timer.Sample sample, String handlerType) {
+        Timer timer = Timer.builder(PROCESSING_DURATION_SECONDS)
+                .tag(TAG_HANDLER, handlerType)
+                .description("Time taken to process an AMIE packet by handler type")
+                .register(meterRegistry);
+        sample.stop(timer);
+    }
+
+    /**
+     * Increments the counter tracking the number of packets fetched during a poller run.
+     *
+     * @param count the number of packets fetched
+     */
+    public void recordPollerFetch(int count) {
+        Counter.builder(POLLER_PACKETS_FETCHED)
+                .description("Total number of AMIE packets fetched by the poller")
+                .register(meterRegistry)
+                .increment(count);
+    }
+}

--- a/allocations/access-ci-service/src/main/java/org/apache/custos/access/ci/service/model/amie/AuditAction.java
+++ b/allocations/access-ci-service/src/main/java/org/apache/custos/access/ci/service/model/amie/AuditAction.java
@@ -1,0 +1,39 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ */
+package org.apache.custos.access.ci.service.model.amie;
+
+/**
+ * Enum of auditable actions performed during AMIE packet processing.
+ */
+public enum AuditAction {
+    CREATE_PERSON,
+    UPDATE_PERSON,
+    DELETE_PERSON,
+    MERGE_PERSONS,
+    CREATE_ACCOUNT,
+    CREATE_PROJECT,
+    INACTIVATE_PROJECT,
+    REACTIVATE_PROJECT,
+    CREATE_MEMBERSHIP,
+    INACTIVATE_MEMBERSHIP,
+    REACTIVATE_MEMBERSHIP,
+    PERSIST_DNS,
+    REPLY_SENT,
+    TRANSACTION_COMPLETE
+}

--- a/allocations/access-ci-service/src/main/java/org/apache/custos/access/ci/service/model/amie/AuditLogEntity.java
+++ b/allocations/access-ci-service/src/main/java/org/apache/custos/access/ci/service/model/amie/AuditLogEntity.java
@@ -1,0 +1,130 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ */
+package org.apache.custos.access.ci.service.model.amie;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+
+import java.time.Instant;
+
+@Entity
+@Table(name = "amie_audit_log")
+public class AuditLogEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "packet_id", nullable = false)
+    private PacketEntity packet;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "event_id")
+    private ProcessingEventEntity event;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "action", columnDefinition = "VARCHAR(64)", nullable = false)
+    private AuditAction action;
+
+    @Column(name = "entity_type", nullable = false, length = 64)
+    private String entityType;
+
+    @Column(name = "entity_id", length = 255)
+    private String entityId;
+
+    @Column(name = "summary", columnDefinition = "TEXT")
+    private String summary;
+
+    @Column(name = "created_at", nullable = false)
+    private Instant createdAt = Instant.now();
+
+    public Long getId() {
+        return id;
+    }
+
+    public void setId(Long id) {
+        this.id = id;
+    }
+
+    public PacketEntity getPacket() {
+        return packet;
+    }
+
+    public void setPacket(PacketEntity packet) {
+        this.packet = packet;
+    }
+
+    public ProcessingEventEntity getEvent() {
+        return event;
+    }
+
+    public void setEvent(ProcessingEventEntity event) {
+        this.event = event;
+    }
+
+    public AuditAction getAction() {
+        return action;
+    }
+
+    public void setAction(AuditAction action) {
+        this.action = action;
+    }
+
+    public String getEntityType() {
+        return entityType;
+    }
+
+    public void setEntityType(String entityType) {
+        this.entityType = entityType;
+    }
+
+    public String getEntityId() {
+        return entityId;
+    }
+
+    public void setEntityId(String entityId) {
+        this.entityId = entityId;
+    }
+
+    public String getSummary() {
+        return summary;
+    }
+
+    public void setSummary(String summary) {
+        this.summary = summary;
+    }
+
+    public Instant getCreatedAt() {
+        return createdAt;
+    }
+
+    public void setCreatedAt(Instant createdAt) {
+        this.createdAt = createdAt;
+    }
+}

--- a/allocations/access-ci-service/src/main/java/org/apache/custos/access/ci/service/model/amie/ProcessingEventEntity.java
+++ b/allocations/access-ci-service/src/main/java/org/apache/custos/access/ci/service/model/amie/ProcessingEventEntity.java
@@ -71,6 +71,9 @@ public class ProcessingEventEntity {
     @Column(name = "last_error", columnDefinition = "TEXT")
     private String lastError;
 
+    @Column(name = "next_retry_at")
+    private Instant nextRetryAt;
+
     public ProcessingEventEntity() {
         this.id = UUID.randomUUID().toString();
     }
@@ -153,5 +156,13 @@ public class ProcessingEventEntity {
 
     public void setLastError(String lastError) {
         this.lastError = lastError;
+    }
+
+    public Instant getNextRetryAt() {
+        return nextRetryAt;
+    }
+
+    public void setNextRetryAt(Instant nextRetryAt) {
+        this.nextRetryAt = nextRetryAt;
     }
 }

--- a/allocations/access-ci-service/src/main/java/org/apache/custos/access/ci/service/model/amie/ProcessingStatus.java
+++ b/allocations/access-ci-service/src/main/java/org/apache/custos/access/ci/service/model/amie/ProcessingStatus.java
@@ -39,5 +39,10 @@ public enum ProcessingStatus {
     /**
      * The event failed a previous attempt and is waiting to be retried.
      */
-    RETRY_SCHEDULED
+    RETRY_SCHEDULED,
+    /**
+     * The event has exhausted all retry attempts and will never be retried automatically.
+     * Manual intervention is required.
+     */
+    PERMANENTLY_FAILED
 }

--- a/allocations/access-ci-service/src/main/java/org/apache/custos/access/ci/service/repo/ClusterAccountRepository.java
+++ b/allocations/access-ci-service/src/main/java/org/apache/custos/access/ci/service/repo/ClusterAccountRepository.java
@@ -19,14 +19,18 @@
 package org.apache.custos.access.ci.service.repo;
 
 import org.apache.custos.access.ci.service.model.ClusterAccountEntity;
+import org.apache.custos.access.ci.service.model.PersonEntity;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
+import java.util.List;
 import java.util.Optional;
 
 @Repository
 public interface ClusterAccountRepository extends JpaRepository<ClusterAccountEntity, String> {
 
     Optional<ClusterAccountEntity> findByUsername(String username);
+
+    List<ClusterAccountEntity> findByPerson(PersonEntity person);
 
 }

--- a/allocations/access-ci-service/src/main/java/org/apache/custos/access/ci/service/repo/ProjectMembershipRepository.java
+++ b/allocations/access-ci-service/src/main/java/org/apache/custos/access/ci/service/repo/ProjectMembershipRepository.java
@@ -36,4 +36,6 @@ public interface ProjectMembershipRepository extends JpaRepository<ProjectMember
 
     List<ProjectMembershipEntity> findByProjectIdAndClusterAccount_Person_Id(String projectId, String personId);
 
+    List<ProjectMembershipEntity> findByClusterAccount_Person_IdAndProjectIdAndRole(String personId, String projectId, String role);
+
 }

--- a/allocations/access-ci-service/src/main/java/org/apache/custos/access/ci/service/repo/amie/AuditLogRepository.java
+++ b/allocations/access-ci-service/src/main/java/org/apache/custos/access/ci/service/repo/amie/AuditLogRepository.java
@@ -1,0 +1,31 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ */
+package org.apache.custos.access.ci.service.repo.amie;
+
+import org.apache.custos.access.ci.service.model.amie.AuditLogEntity;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+
+@Repository
+public interface AuditLogRepository extends JpaRepository<AuditLogEntity, Long> {
+
+    List<AuditLogEntity> findByPacketIdOrderByCreatedAtAsc(String packetId);
+}

--- a/allocations/access-ci-service/src/main/java/org/apache/custos/access/ci/service/repo/amie/ProcessingEventRepository.java
+++ b/allocations/access-ci-service/src/main/java/org/apache/custos/access/ci/service/repo/amie/ProcessingEventRepository.java
@@ -25,12 +25,21 @@ import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
+import java.time.Instant;
 import java.util.Collection;
 import java.util.List;
 
 @Repository
 public interface ProcessingEventRepository extends JpaRepository<ProcessingEventEntity, String> {
 
-    @Query("SELECT e FROM ProcessingEventEntity e JOIN FETCH e.packet WHERE e.status IN :statuses ORDER BY e.createdAt ASC")
-    List<ProcessingEventEntity> findTop50EventsToProcess(@Param("statuses") Collection<ProcessingStatus> statuses);
+    @Query("""
+            SELECT e FROM ProcessingEventEntity e JOIN FETCH e.packet
+            WHERE e.status IN :statuses
+              AND (e.nextRetryAt IS NULL OR e.nextRetryAt <= :now)
+            ORDER BY e.createdAt ASC
+            LIMIT 50
+            """)
+    List<ProcessingEventEntity> findTop50EventsToProcess(
+            @Param("statuses") Collection<ProcessingStatus> statuses,
+            @Param("now") Instant now);
 }

--- a/allocations/access-ci-service/src/main/java/org/apache/custos/access/ci/service/service/AuditService.java
+++ b/allocations/access-ci-service/src/main/java/org/apache/custos/access/ci/service/service/AuditService.java
@@ -1,0 +1,86 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ */
+package org.apache.custos.access.ci.service.service;
+
+import org.apache.custos.access.ci.service.model.amie.AuditAction;
+import org.apache.custos.access.ci.service.model.amie.AuditLogEntity;
+import org.apache.custos.access.ci.service.repo.amie.AuditLogRepository;
+import org.apache.custos.access.ci.service.repo.amie.PacketRepository;
+import org.apache.custos.access.ci.service.repo.amie.ProcessingEventRepository;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Service;
+
+/**
+ * Service for recording audit log entries during AMIE packet processing.
+ *
+ * <p>This service is not annotated with {@code @Transactional},
+ * so that this be in the caller's active transaction without introducing a new one.
+ * There must be an active transaction when invoking {@link #log}.
+ */
+@Service
+public class AuditService {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(AuditService.class);
+
+    private final AuditLogRepository auditLogRepository;
+    private final PacketRepository packetRepository;
+    private final ProcessingEventRepository processingEventRepository;
+
+    public AuditService(AuditLogRepository auditLogRepository,
+                        PacketRepository packetRepository,
+                        ProcessingEventRepository processingEventRepository) {
+        this.auditLogRepository = auditLogRepository;
+        this.packetRepository = packetRepository;
+        this.processingEventRepository = processingEventRepository;
+    }
+
+    /**
+     * Records an audit log entry for an AMIE packet processing action.
+     *
+     * @param packetId   the ID of the packet being processed (not null)
+     * @param eventId    the ID of the processing event, or null if not associated with an event
+     * @param action     the auditable action performed
+     * @param entityType a label describing the type of entity affected (e.g., "Person", "Project")
+     * @param entityId   the ID of the affected entity, or null if not applicable
+     * @param summary    a human-readable description of what happened, or null
+     */
+    public void log(String packetId,
+                    String eventId,
+                    AuditAction action,
+                    String entityType,
+                    String entityId,
+                    String summary) {
+
+        AuditLogEntity entry = new AuditLogEntity();
+        entry.setPacket(packetRepository.getReferenceById(packetId));
+        if (eventId != null) {
+            entry.setEvent(processingEventRepository.getReferenceById(eventId));
+        }
+        entry.setAction(action);
+        entry.setEntityType(entityType);
+        entry.setEntityId(entityId);
+        entry.setSummary(summary);
+
+        auditLogRepository.save(entry);
+
+        LOGGER.debug("Audit entry recorded: packetId={}, eventId={}, action={}, entityType={}, entityId={}",
+                packetId, eventId, action, entityType, entityId);
+    }
+}

--- a/allocations/access-ci-service/src/main/java/org/apache/custos/access/ci/service/service/PersonService.java
+++ b/allocations/access-ci-service/src/main/java/org/apache/custos/access/ci/service/service/PersonService.java
@@ -27,6 +27,7 @@ import org.apache.custos.access.ci.service.repo.PersonDnsRepository;
 import org.apache.custos.access.ci.service.repo.PersonRepository;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.util.Assert;
@@ -111,17 +112,16 @@ public class PersonService {
         PersonEntity person = personRepository.findById(personId)
                 .orElseThrow(() -> new IllegalArgumentException("Unknown local PersonID: " + personId));
 
-        // Update fields
-        if (body.has("FirstName")) person.setFirstName(body.path("FirstName").asText(person.getFirstName()));
-        if (body.has("LastName")) person.setLastName(body.path("LastName").asText(person.getLastName()));
-        if (body.has("Email")) person.setEmail(body.path("Email").asText(person.getEmail()));
-        person.setOrganization(body.has("Organization") ? body.path("Organization").asText(null) : null);
-        person.setOrgCode(body.has("OrgCode") ? body.path("OrgCode").asText(null) : null);
-        person.setNsfStatusCode(body.has("NsfStatusCode") ? body.path("NsfStatusCode").asText(null) : null);
+        if (body.has("UserFirstName")) person.setFirstName(body.path("UserFirstName").asText(person.getFirstName()));
+        if (body.has("UserLastName")) person.setLastName(body.path("UserLastName").asText(person.getLastName()));
+        if (body.has("UserEmail")) person.setEmail(body.path("UserEmail").asText(person.getEmail()));
+        if (body.has("UserOrganization")) person.setOrganization(body.path("UserOrganization").asText(null));
+        if (body.has("UserOrgCode")) person.setOrgCode(body.path("UserOrgCode").asText(null));
+        if (body.has("NsfStatusCode")) person.setNsfStatusCode(body.path("NsfStatusCode").asText(null));
         personRepository.save(person);
 
         Set<String> newDns = new HashSet<>();
-        JsonNode dnList = body.path("DnList");
+        JsonNode dnList = body.path("UserDnList");
         if (dnList != null && dnList.isArray()) {
             for (JsonNode dnNode : dnList) {
                 String dn = dnNode.asText(null);
@@ -130,7 +130,9 @@ public class PersonService {
         }
 
         if (newDns.isEmpty()) {
-            personDnsRepository.deleteByPerson_Id(personId);
+            if (body.has("UserDnList")) {
+                personDnsRepository.deleteByPerson_Id(personId);
+            }
         } else {
             personDnsRepository.deleteByPerson_IdAndDnNotIn(personId, new ArrayList<>(newDns));
             for (String dn : newDns) {
@@ -140,6 +142,47 @@ public class PersonService {
                     p.setDn(dn);
                     personDnsRepository.save(p);
                 }
+            }
+        }
+    }
+
+    @Transactional
+    public void persistDnsForPerson(String personId, JsonNode dnList) {
+        Assert.hasText(personId, "personId must not be blank");
+
+        if (dnList == null || !dnList.isArray() || dnList.isEmpty()) {
+            return;
+        }
+
+        PersonEntity person = personRepository.findById(personId)
+                .orElseThrow(() -> new IllegalArgumentException("Unknown local PersonID: " + personId));
+
+        Set<String> incomingDns = new HashSet<>();
+        for (JsonNode dnNode : dnList) {
+            String dn = dnNode.asText(null);
+            if (dn != null && !dn.isBlank()) {
+                incomingDns.add(dn);
+            }
+        }
+
+        if (incomingDns.isEmpty()) {
+            return;
+        }
+
+        for (String dn : incomingDns) {
+            if (!personDnsRepository.existsByPerson_IdAndDn(personId, dn)) {
+                PersonDnsEntity pde = new PersonDnsEntity();
+                pde.setPerson(person);
+                pde.setDn(dn);
+                try {
+                    personDnsRepository.save(pde);
+                    LOGGER.info("Persisted new DN for person [{}].", personId);
+                    LOGGER.debug("Persisted DN [{}] for person [{}].", dn, personId);
+                } catch (DataIntegrityViolationException ex) {
+                    LOGGER.debug("DN already exists for person [{}] (concurrent insert), skipping.", personId);
+                }
+            } else {
+                LOGGER.debug("DN [{}] already exists for person [{}], skipping.", dn, personId);
             }
         }
     }

--- a/allocations/access-ci-service/src/main/java/org/apache/custos/access/ci/service/service/ProjectMembershipService.java
+++ b/allocations/access-ci-service/src/main/java/org/apache/custos/access/ci/service/service/ProjectMembershipService.java
@@ -58,9 +58,20 @@ public class ProjectMembershipService {
     @Transactional
     public ProjectMembershipEntity createMembership(String projectId, String clusterAccountId, String role) {
         Optional<ProjectMembershipEntity> existing = membershipRepository.findByProjectIdAndClusterAccountId(projectId, clusterAccountId);
+
         if (existing.isPresent()) {
-            LOGGER.info("Membership already exists for project [{}] and cluster account [{}]", projectId, clusterAccountId);
-            return existing.get();
+            ProjectMembershipEntity membership = existing.get();
+            if (membership.isActive()) {
+                LOGGER.info("Active membership already exists for project [{}] and cluster account [{}], returning existing record",
+                        projectId, clusterAccountId);
+                return membership;
+            }
+            LOGGER.info("Reactivating inactive membership for project [{}] and cluster account [{}] with role [{}]",
+                    projectId, clusterAccountId, role);
+            membership.setActive(true);
+            membership.setRole(role);
+            membershipRepository.save(membership);
+            return membership;
         }
 
         ProjectEntity project = projectRepository.findById(projectId)
@@ -88,19 +99,20 @@ public class ProjectMembershipService {
      * @param personId  Person ID
      */
     @Transactional
-    public void inactivateMembershipsByPersonAndProject(String projectId, String personId) {
+    public int inactivateMembershipsByPersonAndProject(String projectId, String personId) {
         // TODO - If the user is a PI of a project?
         //  - right now only the membership is turned inactive, no changes to the project
         List<ProjectMembershipEntity> memberships = membershipRepository.findByProjectIdAndClusterAccount_Person_Id(projectId, personId);
 
         if (memberships.isEmpty()) {
-            LOGGER.warn("No memberships found for person [{}] on project [{}]. No action taken.", personId, projectId);
-            return;
+            LOGGER.warn("No memberships found for person [{}] on project [{}]. Inactivation had no effect.", personId, projectId);
+            return 0;
         }
 
         memberships.forEach(membership -> membership.setActive(false));
         membershipRepository.saveAll(memberships);
         LOGGER.info("Inactivated {} membership(s) for person [{}] on project [{}]", memberships.size(), personId, projectId);
+        return memberships.size();
     }
 
     /**
@@ -143,17 +155,18 @@ public class ProjectMembershipService {
      * @param personId  Person ID
      */
     @Transactional
-    public void reactivateMembershipsByPersonAndProject(String projectId, String personId) {
+    public int reactivateMembershipsByPersonAndProject(String projectId, String personId) {
         List<ProjectMembershipEntity> memberships = membershipRepository.findByProjectIdAndClusterAccount_Person_Id(projectId, personId);
 
         if (memberships.isEmpty()) {
-            LOGGER.warn("No memberships found for person [{}] on project [{}]. No action taken.", personId, projectId);
-            return;
+            LOGGER.warn("No memberships found for person [{}] on project [{}]. Reactivation had no effect.", personId, projectId);
+            return 0;
         }
 
         memberships.forEach(membership -> membership.setActive(true));
         membershipRepository.saveAll(memberships);
         LOGGER.info("Reactivated {} membership(s) for person [{}] on project [{}]", memberships.size(), personId, projectId);
+        return memberships.size();
     }
 
 }

--- a/allocations/access-ci-service/src/main/java/org/apache/custos/access/ci/service/service/UserAccountService.java
+++ b/allocations/access-ci-service/src/main/java/org/apache/custos/access/ci/service/service/UserAccountService.java
@@ -23,9 +23,11 @@ import org.apache.custos.access.ci.service.model.PersonEntity;
 import org.apache.custos.access.ci.service.repo.ClusterAccountRepository;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.List;
 import java.util.UUID;
 
 /**
@@ -52,6 +54,14 @@ public class UserAccountService {
     public ClusterAccountEntity provisionClusterAccount(PersonEntity person) {
         // TODO Replace with external source of truth (e.g., COmanage) lookup for PersonID and username
 
+        List<ClusterAccountEntity> existing = clusterAccountRepository.findByPerson(person);
+        if (!existing.isEmpty()) {
+            ClusterAccountEntity account = existing.get(0);
+            LOGGER.info("Cluster account already exists for person [{}], returning existing account with username [{}]",
+                    person.getId(), account.getUsername());
+            return account;
+        }
+
         String proposedUsername = (person.getFirstName().trim().charAt(0) + person.getLastName().trim().replace(" ", "-")).toLowerCase();
         String uniqueUsername = ensureUniqueUsername(proposedUsername);
 
@@ -61,9 +71,20 @@ public class UserAccountService {
         newClusterAccount.setId(UUID.randomUUID().toString());
         newClusterAccount.setPerson(person);
         newClusterAccount.setUsername(uniqueUsername);
-        clusterAccountRepository.save(newClusterAccount);
 
-        return newClusterAccount;
+        ClusterAccountEntity account;
+        try {
+            account = clusterAccountRepository.save(newClusterAccount);
+        } catch (DataIntegrityViolationException e) {
+            List<ClusterAccountEntity> retryLookup = clusterAccountRepository.findByPerson(person);
+            if (!retryLookup.isEmpty()) {
+                LOGGER.warn("Concurrent account creation detected for person [{}]; returning existing account.", person.getId());
+                return retryLookup.get(0);
+            }
+            throw e; // Re-throw if it was a different constraint violation
+        }
+
+        return account;
     }
 
     private String ensureUniqueUsername(String baseUsername) {
@@ -79,4 +100,3 @@ public class UserAccountService {
         return candidate;
     }
 }
-

--- a/allocations/access-ci-service/src/main/java/org/apache/custos/access/ci/service/worker/amie/ProcessingEventWorker.java
+++ b/allocations/access-ci-service/src/main/java/org/apache/custos/access/ci/service/worker/amie/ProcessingEventWorker.java
@@ -19,7 +19,9 @@
 package org.apache.custos.access.ci.service.worker.amie;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import io.micrometer.core.instrument.Timer;
 import org.apache.custos.access.ci.service.handler.amie.PacketRouter;
+import org.apache.custos.access.ci.service.metrics.AmieMetrics;
 import org.apache.custos.access.ci.service.model.amie.PacketEntity;
 import org.apache.custos.access.ci.service.model.amie.PacketStatus;
 import org.apache.custos.access.ci.service.model.amie.ProcessingErrorEntity;
@@ -31,6 +33,7 @@ import org.apache.custos.access.ci.service.repo.amie.ProcessingErrorRepository;
 import org.apache.custos.access.ci.service.repo.amie.ProcessingEventRepository;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.slf4j.MDC;
 import org.springframework.context.annotation.Lazy;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Component;
@@ -76,6 +79,7 @@ public class ProcessingEventWorker {
     private final PacketRepository packetRepo;
     private final ProcessingErrorRepository errorRepo;
     private final PacketRouter router;
+    private final AmieMetrics amieMetrics;
     private final ObjectMapper objectMapper = new ObjectMapper();
     private final ProcessingEventWorker self;
 
@@ -83,11 +87,13 @@ public class ProcessingEventWorker {
                                  PacketRepository packetRepo,
                                  ProcessingErrorRepository errorRepo,
                                  PacketRouter router,
+                                 AmieMetrics amieMetrics,
                                  @Lazy ProcessingEventWorker self) {
         this.eventRepo = eventRepo;
         this.packetRepo = packetRepo;
         this.errorRepo = errorRepo;
         this.router = router;
+        this.amieMetrics = amieMetrics;
         this.self = self;
     }
 
@@ -109,18 +115,33 @@ public class ProcessingEventWorker {
 
         for (ProcessingEventEntity event : eventsToProcess) {
             String eventId = event.getId();
+            PacketEntity packet = event.getPacket();
+
+            MDC.put("packetId", packet.getId());
+            MDC.put("amieId", String.valueOf(packet.getAmieId()));
+            MDC.put("packetType", packet.getType());
+
+            Timer.Sample timerSample = amieMetrics.startProcessingTimer();
             try {
                 self.executeEventInTransaction(event);
             } catch (Exception e) {
                 LOGGER.error("Transaction failed for eventId [{}]. Opening recovery transaction to record failure.",
                         eventId, e);
+                amieMetrics.stopProcessingTimer(timerSample, packet.getType());
                 try {
                     self.recordFailureInNewTransaction(eventId, e);
                 } catch (Exception recoveryEx) {
                     LOGGER.error("CRITICAL: Recovery transaction also failed for eventId [{}]. " +
                             "Event may remain stuck until the next worker cycle.", eventId, recoveryEx);
                 }
+                continue;
+            } finally {
+                MDC.remove("packetId");
+                MDC.remove("amieId");
+                MDC.remove("packetType");
+                MDC.remove("handler");
             }
+            amieMetrics.stopProcessingTimer(timerSample, packet.getType());
         }
     }
 
@@ -136,7 +157,7 @@ public class ProcessingEventWorker {
         eventRepo.saveAndFlush(event);
 
         var packetJson = objectMapper.readTree(packet.getRawJson());
-        router.route(packetJson, packet);
+        router.route(packetJson, packet, event.getId());
 
         handleSuccess(event, packet);
     }
@@ -166,10 +187,13 @@ public class ProcessingEventWorker {
         if (isRetryable) {
             Instant nextRetryAt = computeNextRetryAt(effectiveAttempts);
             event.setNextRetryAt(nextRetryAt);
+            amieMetrics.recordRetry();
+            amieMetrics.recordPacketProcessed(packet.getType(), "retry_scheduled");
             LOGGER.warn("Event [{}] for packet amie_id [{}] failed on attempt {}/{}. Scheduled for retry after [{}].",
                     eventId, packet.getAmieId(), effectiveAttempts, MAX_ATTEMPTS, nextRetryAt);
         } else {
             event.setNextRetryAt(null);
+            amieMetrics.recordPacketProcessed(packet.getType(), "permanently_failed");
             LOGGER.error("Event [{}] for packet amie_id [{}] is PERMANENTLY_FAILED after {} attempt(s). Manual intervention required.",
                     eventId, packet.getAmieId(), effectiveAttempts);
             packet.setStatus(PacketStatus.FAILED);
@@ -202,6 +226,8 @@ public class ProcessingEventWorker {
             packet.setDecodedAt(Instant.now());
             packetRepo.save(packet);
         }
+
+        amieMetrics.recordPacketProcessed(packet.getType(), "succeeded");
 
         LOGGER.info("Successfully processed event [{}] for packet amie_id [{}].",
                 event.getType(), packet.getAmieId());

--- a/allocations/access-ci-service/src/main/java/org/apache/custos/access/ci/service/worker/amie/ProcessingEventWorker.java
+++ b/allocations/access-ci-service/src/main/java/org/apache/custos/access/ci/service/worker/amie/ProcessingEventWorker.java
@@ -43,14 +43,34 @@ import java.time.Instant;
 import java.util.List;
 
 /**
- * A scheduled worker that fetches for new/ processing events and executes them.
- * State of an event (NEW -> RUNNING -> SUCCEEDED/FAILED)
+ * Scheduled worker that polls for pending AMIE processing events and executes them.
+ * Failures are recorded in a separate transaction to prevent infinite retry loops.
+ *
+ * <pre>
+ * NEW → RUNNING → SUCCEEDED
+ *                → RETRY_SCHEDULED → (backoff) → RUNNING → ...
+ *                → PERMANENTLY_FAILED (after MAX_ATTEMPTS)
+ * </pre>
  */
 @Component
 public class ProcessingEventWorker {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(ProcessingEventWorker.class);
-    private static final int MAX_ATTEMPTS = 3;
+
+    /**
+     * Maximum number of execution attempts before an event is permanently failed.
+     */
+    static final int MAX_ATTEMPTS = 3;
+
+    /**
+     * Base delay in seconds for exponential backoff between retry attempts.
+     */
+    private static final long BASE_BACKOFF_SECONDS = 30L;
+
+    /**
+     * Upper bound on the computed backoff delay (10 minutes).
+     */
+    private static final long MAX_BACKOFF_SECONDS = 600L;
 
     private final ProcessingEventRepository eventRepo;
     private final PacketRepository packetRepo;
@@ -59,8 +79,11 @@ public class ProcessingEventWorker {
     private final ObjectMapper objectMapper = new ObjectMapper();
     private final ProcessingEventWorker self;
 
-    public ProcessingEventWorker(ProcessingEventRepository eventRepo, PacketRepository packetRepo,
-                                 ProcessingErrorRepository errorRepo, PacketRouter router, @Lazy ProcessingEventWorker self) {
+    public ProcessingEventWorker(ProcessingEventRepository eventRepo,
+                                 PacketRepository packetRepo,
+                                 ProcessingErrorRepository errorRepo,
+                                 PacketRouter router,
+                                 @Lazy ProcessingEventWorker self) {
         this.eventRepo = eventRepo;
         this.packetRepo = packetRepo;
         this.errorRepo = errorRepo;
@@ -69,49 +92,109 @@ public class ProcessingEventWorker {
     }
 
     /**
-     * Runs on a fixed delay, checks for NEW/RETRY_SCHEDULED events, and processes them one by one on a separate transaction.
+     * Polls for due events and processes each in its own transaction.
      */
     @Scheduled(fixedDelayString = "#{T(org.springframework.boot.convert.DurationStyle).detectAndParse('${access.amie.scheduler.worker-delay}').toMillis()}")
     public void processPendingEvents() {
-        List<ProcessingEventEntity> eventsToProcess = eventRepo.findTop50EventsToProcess(List.of(ProcessingStatus.NEW, ProcessingStatus.RETRY_SCHEDULED));
+        List<ProcessingEventEntity> eventsToProcess =
+                eventRepo.findTop50EventsToProcess(
+                        List.of(ProcessingStatus.NEW, ProcessingStatus.RETRY_SCHEDULED),
+                        Instant.now());
 
-        if (!eventsToProcess.isEmpty()) {
-            LOGGER.info("Found {} event(s) to process.", eventsToProcess.size());
-            eventsToProcess.forEach(event -> {
+        if (eventsToProcess.isEmpty()) {
+            return;
+        }
+
+        LOGGER.info("Found {} event(s) to process.", eventsToProcess.size());
+
+        for (ProcessingEventEntity event : eventsToProcess) {
+            String eventId = event.getId();
+            try {
+                self.executeEventInTransaction(event);
+            } catch (Exception e) {
+                LOGGER.error("Transaction failed for eventId [{}]. Opening recovery transaction to record failure.",
+                        eventId, e);
                 try {
-                    self.executeEventInTransaction(event);
-                } catch (Exception e) {
-                    LOGGER.error("An unexpected error occurred while processing of eventId [{}].", event.getId(), e);
+                    self.recordFailureInNewTransaction(eventId, e);
+                } catch (Exception recoveryEx) {
+                    LOGGER.error("CRITICAL: Recovery transaction also failed for eventId [{}]. " +
+                            "Event may remain stuck until the next worker cycle.", eventId, recoveryEx);
                 }
-            });
+            }
         }
     }
 
     @Transactional(propagation = Propagation.REQUIRES_NEW)
-    public void executeEventInTransaction(ProcessingEventEntity event) {
+    public void executeEventInTransaction(ProcessingEventEntity event) throws Exception {
         PacketEntity packet = event.getPacket();
-        LOGGER.info("Processing event [{}] for packet amie_id [{}]. Attempt: {}", event.getType(), packet.getAmieId(), event.getAttempts() + 1);
+        LOGGER.info("Processing event [{}] for packet amie_id [{}]. Attempt: {}",
+                event.getType(), packet.getAmieId(), event.getAttempts() + 1);
 
         event.setStatus(ProcessingStatus.RUNNING);
         event.setStartedAt(Instant.now());
         event.setAttempts(event.getAttempts() + 1);
         eventRepo.saveAndFlush(event);
 
-        try {
-            var packetJson = objectMapper.readTree(packet.getRawJson());
-            router.route(packetJson, packet);
+        var packetJson = objectMapper.readTree(packet.getRawJson());
+        router.route(packetJson, packet);
 
-            handleSuccess(event, packet);
+        handleSuccess(event, packet);
+    }
 
-        } catch (Exception e) {
-            LOGGER.error("Event processing failed for packet amie_id [{}]. Attempt {} of {}.", packet.getAmieId(), event.getAttempts(), MAX_ATTEMPTS, e);
-            handleFailure(event, packet, e);
+    @Transactional(propagation = Propagation.REQUIRES_NEW)
+    public void recordFailureInNewTransaction(String eventId, Exception cause) {
+        ProcessingEventEntity event = eventRepo.findById(eventId).orElse(null);
+        if (event == null) {
+            LOGGER.error("Cannot record failure: event [{}] not found in the database.", eventId);
+            return;
         }
+
+        PacketEntity packet = event.getPacket();
+
+        int effectiveAttempts = event.getAttempts() + 1;
+        event.setAttempts(effectiveAttempts);
+
+        boolean isRetryable = effectiveAttempts < MAX_ATTEMPTS;
+        ProcessingStatus newStatus = isRetryable
+                ? ProcessingStatus.RETRY_SCHEDULED
+                : ProcessingStatus.PERMANENTLY_FAILED;
+
+        event.setStatus(newStatus);
+        event.setLastError(cause.getMessage());
+        event.setFinishedAt(Instant.now());
+
+        if (isRetryable) {
+            Instant nextRetryAt = computeNextRetryAt(effectiveAttempts);
+            event.setNextRetryAt(nextRetryAt);
+            LOGGER.warn("Event [{}] for packet amie_id [{}] failed on attempt {}/{}. Scheduled for retry after [{}].",
+                    eventId, packet.getAmieId(), effectiveAttempts, MAX_ATTEMPTS, nextRetryAt);
+        } else {
+            event.setNextRetryAt(null);
+            LOGGER.error("Event [{}] for packet amie_id [{}] is PERMANENTLY_FAILED after {} attempt(s). Manual intervention required.",
+                    eventId, packet.getAmieId(), effectiveAttempts);
+            packet.setStatus(PacketStatus.FAILED);
+            packet.setLastError(cause.getMessage());
+            packetRepo.save(packet);
+        }
+
+        eventRepo.save(event);
+
+        ProcessingErrorEntity error = new ProcessingErrorEntity();
+        error.setPacket(packet);
+        error.setEvent(event);
+        error.setSummary(cause.getClass().getSimpleName() + ": " + cause.getMessage());
+        String stackTrace = getStackTraceAsString(cause);
+        if (stackTrace.length() > 8000) {
+            stackTrace = stackTrace.substring(0, 8000) + "\n... [truncated]";
+        }
+        error.setDetail(stackTrace);
+        errorRepo.save(error);
     }
 
     private void handleSuccess(ProcessingEventEntity event, PacketEntity packet) {
         event.setStatus(ProcessingStatus.SUCCEEDED);
         event.setFinishedAt(Instant.now());
+        event.setNextRetryAt(null);
         eventRepo.save(event);
 
         if (event.getType() == ProcessingEventType.DECODE_PACKET) {
@@ -120,35 +203,16 @@ public class ProcessingEventWorker {
             packetRepo.save(packet);
         }
 
-        LOGGER.info("Successfully processed event [{}] for packet amie_id [{}].", event.getType(), packet.getAmieId());
+        LOGGER.info("Successfully processed event [{}] for packet amie_id [{}].",
+                event.getType(), packet.getAmieId());
     }
 
-    private void handleFailure(ProcessingEventEntity event, PacketEntity packet, Exception e) {
-        // Check if the event should be retried or marked as failed
-        boolean isRetryable = event.getAttempts() < MAX_ATTEMPTS;
-        ProcessingStatus newStatus = isRetryable ? ProcessingStatus.RETRY_SCHEDULED : ProcessingStatus.FAILED;
-
-        event.setStatus(newStatus);
-        event.setLastError(e.getMessage());
-        event.setFinishedAt(Instant.now());
-        eventRepo.save(event);
-
-        if (!isRetryable) {
-            LOGGER.error("Event for packet amie_id [{}] has failed permanently after {} attempts.", packet.getAmieId(), event.getAttempts());
-            packet.setStatus(PacketStatus.FAILED);
-            packet.setLastError(e.getMessage());
-            packetRepo.save(packet);
-
-        } else {
-            LOGGER.warn("Event for packet amie_id [{}] will be retried. Status set to {}.", packet.getAmieId(), newStatus);
-        }
-
-        ProcessingErrorEntity error = new ProcessingErrorEntity();
-        error.setPacket(packet);
-        error.setEvent(event);
-        error.setSummary(e.getClass().getSimpleName() + ": " + e.getMessage());
-        error.setDetail(getStackTraceAsString(e));
-        errorRepo.save(error);
+    // Exponential backoff: BASE * 2^(attempt-1), capped at MAX_BACKOFF_SECONDS.
+    static Instant computeNextRetryAt(int attemptNumber) {
+        long exponent = Math.max(0, attemptNumber - 1);
+        long delaySec = BASE_BACKOFF_SECONDS * (1L << exponent);
+        delaySec = Math.min(delaySec, MAX_BACKOFF_SECONDS);
+        return Instant.now().plusSeconds(delaySec);
     }
 
     private String getStackTraceAsString(Exception e) {

--- a/allocations/access-ci-service/src/main/resources/application.yml
+++ b/allocations/access-ci-service/src/main/resources/application.yml
@@ -18,6 +18,8 @@ server:
   port: 8083
 
 spring:
+  profiles:
+    active: dev
   application:
     name: access-ci-service
   datasource:
@@ -54,6 +56,19 @@ logging:
     level: '%5p [${spring.application.name:},%X{traceId:-},%X{spanId:-}]'
   level:
     root: info
+
+management:
+  endpoints:
+    web:
+      exposure:
+        include: health, prometheus, info
+  endpoint:
+    health:
+      show-details: when-authorized
+  prometheus:
+    metrics:
+      export:
+        enabled: true
 
 springdoc:
   swagger-ui:

--- a/allocations/access-ci-service/src/main/resources/db/migration/V2__add_next_retry_at_to_processing_events.sql
+++ b/allocations/access-ci-service/src/main/resources/db/migration/V2__add_next_retry_at_to_processing_events.sql
@@ -1,0 +1,5 @@
+-- Add retry backoff support to processing events.
+
+ALTER TABLE amie_processing_events
+    ADD COLUMN next_retry_at TIMESTAMP(6) NULL DEFAULT NULL,
+    ADD INDEX idx_amie_events_next_retry_at (next_retry_at);

--- a/allocations/access-ci-service/src/main/resources/db/migration/V3__create_audit_log.sql
+++ b/allocations/access-ci-service/src/main/resources/db/migration/V3__create_audit_log.sql
@@ -1,0 +1,36 @@
+--  Licensed to the Apache Software Foundation (ASF) under one or more
+--  contributor license agreements.  See the NOTICE file distributed with
+--  this work for additional information regarding copyright ownership.
+--  The ASF licenses this file to You under the Apache License, Version 2.0
+--  (the "License"); you may not use this file except in compliance with
+--  the License.  You may obtain a copy of the License at
+--
+--      http://www.apache.org/licenses/LICENSE-2.0
+--
+--  Unless required by applicable law or agreed to in writing, software
+--  distributed under the License is distributed on an "AS IS" BASIS,
+--  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+--  See the License for the specific language governing permissions and
+--  limitations under the License.
+
+-- Audit log for handler actions during AMIE packet processing.
+
+CREATE TABLE amie_audit_log
+(
+    id          BIGINT       NOT NULL AUTO_INCREMENT,
+    packet_id   VARCHAR(255) NOT NULL,
+    event_id    VARCHAR(255) NULL,
+    action      VARCHAR(64)  NOT NULL,
+    entity_type VARCHAR(64)  NOT NULL,
+    entity_id   VARCHAR(255) NULL,
+    summary     TEXT         NULL,
+    created_at  TIMESTAMP(6) NOT NULL DEFAULT CURRENT_TIMESTAMP(6),
+    PRIMARY KEY (id),
+    CONSTRAINT fk_audit_packet FOREIGN KEY (packet_id) REFERENCES amie_packets (id) ON DELETE CASCADE,
+    CONSTRAINT fk_audit_event FOREIGN KEY (event_id) REFERENCES amie_processing_events (id) ON DELETE SET NULL,
+    KEY idx_audit_packet_id (packet_id),
+    KEY idx_audit_action (action),
+    KEY idx_audit_created_at (created_at)
+) ENGINE = InnoDB
+  DEFAULT CHARSET = utf8mb4
+  COLLATE = utf8mb4_unicode_ci;

--- a/allocations/access-ci-service/src/main/resources/distribution/conf/application.yml
+++ b/allocations/access-ci-service/src/main/resources/distribution/conf/application.yml
@@ -18,6 +18,8 @@ server:
   port: 8083
 
 spring:
+  profiles:
+    active: prod
   application:
     name: access-ci-service
   datasource:
@@ -54,6 +56,19 @@ logging:
     level: '%5p [${spring.application.name:},%X{traceId:-},%X{spanId:-}]'
   level:
     root: info
+
+management:
+  endpoints:
+    web:
+      exposure:
+        include: health, prometheus, info
+  endpoint:
+    health:
+      show-details: when-authorized
+  prometheus:
+    metrics:
+      export:
+        enabled: true
 
 springdoc:
   swagger-ui:

--- a/allocations/access-ci-service/src/main/resources/distribution/conf/logback-spring.xml
+++ b/allocations/access-ci-service/src/main/resources/distribution/conf/logback-spring.xml
@@ -23,33 +23,77 @@
 <configuration>
     <include resource="org/springframework/boot/logging/logback/base.xml"/>
     <springProperty scope="context" name="appName" source="spring.application.name"/>
-    <!-- Rolling File Appender -->
-    <appender name="FILE" class="ch.qos.logback.core.rolling.RollingFileAppender">
-        <file>logs/custos-amie-decoder.log</file>
-        <encoder>
-            <pattern>%date{YYYY-MM-dd HH:mm:ss.SSS} app=${appName}, host=${HOSTNAME}, traceID=%X{traceId:-NONE},
-                level=%-5level, [%thread] %logger{36} - %msg%n
-            </pattern>
-        </encoder>
-        <rollingPolicy class="ch.qos.logback.core.rolling.SizeAndTimeBasedRollingPolicy">
-            <fileNamePattern>logs/%d{yyyy-MM}/custos-amie-decoder-%d{MM-dd-yyyy}-%i.log.gz</fileNamePattern>
-            <maxFileSize>10MB</maxFileSize>
-            <maxHistory>30</maxHistory>
-            <totalSizeCap>1GB</totalSizeCap>
-        </rollingPolicy>
-    </appender>
 
-    <appender name="ASYNC_FILE" class="ch.qos.logback.classic.AsyncAppender">
-        <appender-ref ref="FILE"/>
-        <queueSize>500</queueSize>
-        <discardingThreshold>0</discardingThreshold>
-        <includeCallerData>true</includeCallerData>
-    </appender>
+    <!-- ================================================================ -->
+    <!-- DEV / DEFAULT PROFILE — human-readable text format with MDC      -->
+    <!-- ================================================================ -->
+    <springProfile name="default,dev">
 
-    <logger name="org.hibernate" level="ERROR"/>
-    <logger name="org.springframework" level="INFO"/>
+        <appender name="FILE" class="ch.qos.logback.core.rolling.RollingFileAppender">
+            <file>logs/custos-amie-decoder.log</file>
+            <encoder>
+                <pattern>%date{yyyy-MM-dd HH:mm:ss.SSS} app=${appName}, host=${HOSTNAME}, traceId=%X{traceId:-}, packetId=%X{packetId:-}, amieId=%X{amieId:-}, packetType=%X{packetType:-}, handler=%X{handler:-}, level=%-5level, [%thread] %logger{36} - %msg%n</pattern>
+            </encoder>
+            <rollingPolicy class="ch.qos.logback.core.rolling.SizeAndTimeBasedRollingPolicy">
+                <fileNamePattern>logs/%d{yyyy-MM}/custos-amie-decoder-%d{MM-dd-yyyy}-%i.log.gz</fileNamePattern>
+                <maxFileSize>10MB</maxFileSize>
+                <maxHistory>30</maxHistory>
+                <totalSizeCap>1GB</totalSizeCap>
+            </rollingPolicy>
+        </appender>
 
-    <root level="INFO">
-        <appender-ref ref="ASYNC_FILE"/>
-    </root>
+        <appender name="ASYNC_FILE" class="ch.qos.logback.classic.AsyncAppender">
+            <appender-ref ref="FILE"/>
+            <queueSize>500</queueSize>
+            <discardingThreshold>0</discardingThreshold>
+            <includeCallerData>true</includeCallerData>
+        </appender>
+
+        <logger name="org.hibernate" level="ERROR"/>
+        <logger name="org.springframework" level="INFO"/>
+
+        <root level="INFO">
+            <appender-ref ref="ASYNC_FILE"/>
+        </root>
+
+    </springProfile>
+
+    <!-- ================================================================ -->
+    <!-- PROD PROFILE — structured JSON format for log aggregation        -->
+    <!-- ================================================================ -->
+    <springProfile name="prod">
+
+        <appender name="FILE_JSON" class="ch.qos.logback.core.rolling.RollingFileAppender">
+            <file>logs/custos-amie-decoder.log</file>
+            <encoder class="net.logstash.logback.encoder.LogstashEncoder">
+                <includeMdcKeyName>packetId</includeMdcKeyName>
+                <includeMdcKeyName>amieId</includeMdcKeyName>
+                <includeMdcKeyName>packetType</includeMdcKeyName>
+                <includeMdcKeyName>handler</includeMdcKeyName>
+                <includeMdcKeyName>traceId</includeMdcKeyName>
+            </encoder>
+            <rollingPolicy class="ch.qos.logback.core.rolling.SizeAndTimeBasedRollingPolicy">
+                <fileNamePattern>logs/%d{yyyy-MM}/custos-amie-decoder-%d{MM-dd-yyyy}-%i.log.gz</fileNamePattern>
+                <maxFileSize>10MB</maxFileSize>
+                <maxHistory>30</maxHistory>
+                <totalSizeCap>1GB</totalSizeCap>
+            </rollingPolicy>
+        </appender>
+
+        <appender name="ASYNC_FILE" class="ch.qos.logback.classic.AsyncAppender">
+            <appender-ref ref="FILE_JSON"/>
+            <queueSize>500</queueSize>
+            <discardingThreshold>0</discardingThreshold>
+            <includeCallerData>true</includeCallerData>
+        </appender>
+
+        <logger name="org.hibernate" level="ERROR"/>
+        <logger name="org.springframework" level="INFO"/>
+
+        <root level="INFO">
+            <appender-ref ref="ASYNC_FILE"/>
+        </root>
+
+    </springProfile>
+
 </configuration>

--- a/allocations/access-ci-service/src/main/resources/logback-spring.xml
+++ b/allocations/access-ci-service/src/main/resources/logback-spring.xml
@@ -23,33 +23,77 @@
 <configuration>
     <include resource="org/springframework/boot/logging/logback/base.xml"/>
     <springProperty scope="context" name="appName" source="spring.application.name"/>
-    <!-- Rolling File Appender -->
-    <appender name="FILE" class="ch.qos.logback.core.rolling.RollingFileAppender">
-        <file>logs/custos-amie-decoder.log</file>
-        <encoder>
-            <pattern>%date{YYYY-MM-dd HH:mm:ss.SSS} app=${appName}, host=${HOSTNAME}, traceID=%X{traceId:-NONE},
-                level=%-5level, [%thread] %logger{36} - %msg%n
-            </pattern>
-        </encoder>
-        <rollingPolicy class="ch.qos.logback.core.rolling.SizeAndTimeBasedRollingPolicy">
-            <fileNamePattern>logs/%d{yyyy-MM}/custos-amie-decoder-%d{MM-dd-yyyy}-%i.log.gz</fileNamePattern>
-            <maxFileSize>10MB</maxFileSize>
-            <maxHistory>30</maxHistory>
-            <totalSizeCap>1GB</totalSizeCap>
-        </rollingPolicy>
-    </appender>
 
-    <appender name="ASYNC_FILE" class="ch.qos.logback.classic.AsyncAppender">
-        <appender-ref ref="FILE"/>
-        <queueSize>500</queueSize>
-        <discardingThreshold>0</discardingThreshold>
-        <includeCallerData>true</includeCallerData>
-    </appender>
+    <!-- ================================================================ -->
+    <!-- DEV / DEFAULT PROFILE — human-readable text format with MDC      -->
+    <!-- ================================================================ -->
+    <springProfile name="default,dev">
 
-    <logger name="org.hibernate" level="ERROR"/>
-    <logger name="org.springframework" level="INFO"/>
+        <appender name="FILE" class="ch.qos.logback.core.rolling.RollingFileAppender">
+            <file>logs/custos-amie-decoder.log</file>
+            <encoder>
+                <pattern>%date{yyyy-MM-dd HH:mm:ss.SSS} app=${appName}, host=${HOSTNAME}, traceId=%X{traceId:-}, packetId=%X{packetId:-}, amieId=%X{amieId:-}, packetType=%X{packetType:-}, handler=%X{handler:-}, level=%-5level, [%thread] %logger{36} - %msg%n</pattern>
+            </encoder>
+            <rollingPolicy class="ch.qos.logback.core.rolling.SizeAndTimeBasedRollingPolicy">
+                <fileNamePattern>logs/%d{yyyy-MM}/custos-amie-decoder-%d{MM-dd-yyyy}-%i.log.gz</fileNamePattern>
+                <maxFileSize>10MB</maxFileSize>
+                <maxHistory>30</maxHistory>
+                <totalSizeCap>1GB</totalSizeCap>
+            </rollingPolicy>
+        </appender>
 
-    <root level="INFO">
-        <appender-ref ref="ASYNC_FILE"/>
-    </root>
+        <appender name="ASYNC_FILE" class="ch.qos.logback.classic.AsyncAppender">
+            <appender-ref ref="FILE"/>
+            <queueSize>500</queueSize>
+            <discardingThreshold>0</discardingThreshold>
+            <includeCallerData>true</includeCallerData>
+        </appender>
+
+        <logger name="org.hibernate" level="ERROR"/>
+        <logger name="org.springframework" level="INFO"/>
+
+        <root level="INFO">
+            <appender-ref ref="ASYNC_FILE"/>
+        </root>
+
+    </springProfile>
+
+    <!-- ================================================================ -->
+    <!-- PROD PROFILE — structured JSON format for log aggregation        -->
+    <!-- ================================================================ -->
+    <springProfile name="prod">
+
+        <appender name="FILE_JSON" class="ch.qos.logback.core.rolling.RollingFileAppender">
+            <file>logs/custos-amie-decoder.log</file>
+            <encoder class="net.logstash.logback.encoder.LogstashEncoder">
+                <includeMdcKeyName>packetId</includeMdcKeyName>
+                <includeMdcKeyName>amieId</includeMdcKeyName>
+                <includeMdcKeyName>packetType</includeMdcKeyName>
+                <includeMdcKeyName>handler</includeMdcKeyName>
+                <includeMdcKeyName>traceId</includeMdcKeyName>
+            </encoder>
+            <rollingPolicy class="ch.qos.logback.core.rolling.SizeAndTimeBasedRollingPolicy">
+                <fileNamePattern>logs/%d{yyyy-MM}/custos-amie-decoder-%d{MM-dd-yyyy}-%i.log.gz</fileNamePattern>
+                <maxFileSize>10MB</maxFileSize>
+                <maxHistory>30</maxHistory>
+                <totalSizeCap>1GB</totalSizeCap>
+            </rollingPolicy>
+        </appender>
+
+        <appender name="ASYNC_FILE" class="ch.qos.logback.classic.AsyncAppender">
+            <appender-ref ref="FILE_JSON"/>
+            <queueSize>500</queueSize>
+            <discardingThreshold>0</discardingThreshold>
+            <includeCallerData>true</includeCallerData>
+        </appender>
+
+        <logger name="org.hibernate" level="ERROR"/>
+        <logger name="org.springframework" level="INFO"/>
+
+        <root level="INFO">
+            <appender-ref ref="ASYNC_FILE"/>
+        </root>
+
+    </springProfile>
+
 </configuration>

--- a/allocations/access-ci-service/src/test/java/org/apache/custos/access/ci/service/handler/amie/DataAccountCreateHandlerTest.java
+++ b/allocations/access-ci-service/src/test/java/org/apache/custos/access/ci/service/handler/amie/DataAccountCreateHandlerTest.java
@@ -23,6 +23,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import org.apache.custos.access.ci.service.client.amie.AmieClient;
 import org.apache.custos.access.ci.service.model.amie.PacketEntity;
+import org.apache.custos.access.ci.service.service.PersonService;
 import org.apache.custos.access.ci.service.util.JsonTestUtils;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Tag;
@@ -38,6 +39,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 
 @ExtendWith(MockitoExtension.class)
@@ -47,12 +49,15 @@ class DataAccountCreateHandlerTest {
     @Mock
     private AmieClient amieClient;
 
+    @Mock
+    private PersonService personService;
+
     private DataAccountCreateHandler handler;
     private ObjectMapper objectMapper;
 
     @BeforeEach
     void setUp() {
-        handler = new DataAccountCreateHandler(amieClient);
+        handler = new DataAccountCreateHandler(amieClient, personService);
         objectMapper = new ObjectMapper();
     }
 
@@ -115,25 +120,50 @@ class DataAccountCreateHandlerTest {
     }
 
     @Test
-    void handle_withEmptyDnList_shouldProcessSuccessfully() {
+    void handle_withEmptyDnList_shouldNotCallPersonServiceAndSendReply() {
         JsonNode packetJson = createValidPacketJson();
         PacketEntity packetEntity = createPacketEntity();
 
         handler.handle(packetJson, packetEntity);
+
+        verify(personService, never()).persistDnsForPerson(any(), any());
+        //noinspection unchecked
+        verify(amieClient).replyToPacket(eq(12345L), any(Map.class));
+    }
+
+    @Test
+    void handle_withNonEmptyDnList_shouldPersistDnsAndSendReply() {
+        JsonNode packetJson = createPacketJsonWithDnList();
+        PacketEntity packetEntity = createPacketEntity();
+
+        handler.handle(packetJson, packetEntity);
+
+        // Verify personService.persistDnsForPerson was called with the correct personId
+        ArgumentCaptor<String> personIdCaptor = ArgumentCaptor.forClass(String.class);
+        ArgumentCaptor<JsonNode> dnListCaptor = ArgumentCaptor.forClass(JsonNode.class);
+        verify(personService).persistDnsForPerson(personIdCaptor.capture(), dnListCaptor.capture());
+
+        assertThat(personIdCaptor.getValue()).isEqualTo("person-123");
+        assertThat(dnListCaptor.getValue().isArray()).isTrue();
+        assertThat(dnListCaptor.getValue().size()).isEqualTo(2);
 
         //noinspection unchecked
         verify(amieClient).replyToPacket(eq(12345L), any(Map.class));
     }
 
     @Test
-    void handle_withNonEmptyDnList_shouldProcessSuccessfully() {
-        JsonNode packetJson = createPacketJsonWithDnList();
-        PacketEntity packetEntity = createPacketEntity();
+    void handle_withValidPacketContainingDnList_shouldPersistAllDns() {
+        JsonNode incomingPacket = JsonTestUtils.loadMockPacket("data_account_create", "incoming-data.json");
 
-        handler.handle(packetJson, packetEntity);
+        PacketEntity packetEntity = new PacketEntity();
+        packetEntity.setAmieId(233497918L);
+        packetEntity.setType("data_account_create");
 
-        //noinspection unchecked
-        verify(amieClient).replyToPacket(eq(12345L), any(Map.class));
+        handler.handle(incomingPacket, packetEntity);
+
+        ArgumentCaptor<JsonNode> dnListCaptor = ArgumentCaptor.forClass(JsonNode.class);
+        verify(personService).persistDnsForPerson(eq("test-user-person-123"), dnListCaptor.capture());
+        assertThat(dnListCaptor.getValue().size()).isEqualTo(3);
     }
 
     private JsonNode createValidPacketJson() {

--- a/allocations/access-ci-service/src/test/java/org/apache/custos/access/ci/service/handler/amie/DataAccountCreateHandlerTest.java
+++ b/allocations/access-ci-service/src/test/java/org/apache/custos/access/ci/service/handler/amie/DataAccountCreateHandlerTest.java
@@ -23,6 +23,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import org.apache.custos.access.ci.service.client.amie.AmieClient;
 import org.apache.custos.access.ci.service.model.amie.PacketEntity;
+import org.apache.custos.access.ci.service.service.AuditService;
 import org.apache.custos.access.ci.service.service.PersonService;
 import org.apache.custos.access.ci.service.util.JsonTestUtils;
 import org.junit.jupiter.api.BeforeEach;
@@ -52,12 +53,15 @@ class DataAccountCreateHandlerTest {
     @Mock
     private PersonService personService;
 
+    @Mock
+    private AuditService auditService;
+
     private DataAccountCreateHandler handler;
     private ObjectMapper objectMapper;
 
     @BeforeEach
     void setUp() {
-        handler = new DataAccountCreateHandler(amieClient, personService);
+        handler = new DataAccountCreateHandler(amieClient, personService, auditService);
         objectMapper = new ObjectMapper();
     }
 
@@ -75,7 +79,7 @@ class DataAccountCreateHandlerTest {
         packetEntity.setAmieId(233497918L);
         packetEntity.setType("data_account_create");
 
-        handler.handle(incomingPacket, packetEntity);
+        handler.handle(incomingPacket, packetEntity, null);
 
         @SuppressWarnings("unchecked")
         ArgumentCaptor<Map<String, Object>> replyCaptor = ArgumentCaptor.forClass(Map.class);
@@ -104,7 +108,7 @@ class DataAccountCreateHandlerTest {
         JsonNode packetJson = createPacketJsonWithMissingField("ProjectID");
         PacketEntity packetEntity = createPacketEntity();
 
-        assertThatThrownBy(() -> handler.handle(packetJson, packetEntity))
+        assertThatThrownBy(() -> handler.handle(packetJson, packetEntity, null))
                 .isInstanceOf(IllegalArgumentException.class)
                 .hasMessageContaining("'ProjectID' must not be empty");
     }
@@ -114,7 +118,7 @@ class DataAccountCreateHandlerTest {
         JsonNode packetJson = createPacketJsonWithMissingField("PersonID");
         PacketEntity packetEntity = createPacketEntity();
 
-        assertThatThrownBy(() -> handler.handle(packetJson, packetEntity))
+        assertThatThrownBy(() -> handler.handle(packetJson, packetEntity, null))
                 .isInstanceOf(IllegalArgumentException.class)
                 .hasMessageContaining("'PersonID' must not be empty");
     }
@@ -124,7 +128,7 @@ class DataAccountCreateHandlerTest {
         JsonNode packetJson = createValidPacketJson();
         PacketEntity packetEntity = createPacketEntity();
 
-        handler.handle(packetJson, packetEntity);
+        handler.handle(packetJson, packetEntity, null);
 
         verify(personService, never()).persistDnsForPerson(any(), any());
         //noinspection unchecked
@@ -136,7 +140,7 @@ class DataAccountCreateHandlerTest {
         JsonNode packetJson = createPacketJsonWithDnList();
         PacketEntity packetEntity = createPacketEntity();
 
-        handler.handle(packetJson, packetEntity);
+        handler.handle(packetJson, packetEntity, null);
 
         // Verify personService.persistDnsForPerson was called with the correct personId
         ArgumentCaptor<String> personIdCaptor = ArgumentCaptor.forClass(String.class);
@@ -159,7 +163,7 @@ class DataAccountCreateHandlerTest {
         packetEntity.setAmieId(233497918L);
         packetEntity.setType("data_account_create");
 
-        handler.handle(incomingPacket, packetEntity);
+        handler.handle(incomingPacket, packetEntity, null);
 
         ArgumentCaptor<JsonNode> dnListCaptor = ArgumentCaptor.forClass(JsonNode.class);
         verify(personService).persistDnsForPerson(eq("test-user-person-123"), dnListCaptor.capture());

--- a/allocations/access-ci-service/src/test/java/org/apache/custos/access/ci/service/handler/amie/DataProjectCreateHandlerTest.java
+++ b/allocations/access-ci-service/src/test/java/org/apache/custos/access/ci/service/handler/amie/DataProjectCreateHandlerTest.java
@@ -23,6 +23,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import org.apache.custos.access.ci.service.client.amie.AmieClient;
 import org.apache.custos.access.ci.service.model.amie.PacketEntity;
+import org.apache.custos.access.ci.service.service.AuditService;
 import org.apache.custos.access.ci.service.service.PersonService;
 import org.apache.custos.access.ci.service.util.JsonTestUtils;
 import org.junit.jupiter.api.BeforeEach;
@@ -52,12 +53,15 @@ class DataProjectCreateHandlerTest {
     @Mock
     private PersonService personService;
 
+    @Mock
+    private AuditService auditService;
+
     private DataProjectCreateHandler handler;
     private ObjectMapper objectMapper;
 
     @BeforeEach
     void setUp() {
-        handler = new DataProjectCreateHandler(amieClient, personService);
+        handler = new DataProjectCreateHandler(amieClient, personService, auditService);
         objectMapper = new ObjectMapper();
     }
 
@@ -75,7 +79,7 @@ class DataProjectCreateHandlerTest {
         packetEntity.setAmieId(233497909L);
         packetEntity.setType("data_project_create");
 
-        handler.handle(incomingPacket, packetEntity);
+        handler.handle(incomingPacket, packetEntity, null);
 
         @SuppressWarnings("unchecked")
         ArgumentCaptor<Map<String, Object>> replyCaptor = ArgumentCaptor.forClass(Map.class);
@@ -104,7 +108,7 @@ class DataProjectCreateHandlerTest {
         JsonNode packetJson = createPacketJsonWithMissingField("ProjectID");
         PacketEntity packetEntity = createPacketEntity();
 
-        assertThatThrownBy(() -> handler.handle(packetJson, packetEntity))
+        assertThatThrownBy(() -> handler.handle(packetJson, packetEntity, null))
                 .isInstanceOf(IllegalArgumentException.class)
                 .hasMessageContaining("'ProjectID' must not be empty");
     }
@@ -114,7 +118,7 @@ class DataProjectCreateHandlerTest {
         JsonNode packetJson = createPacketJsonWithMissingField("PersonID");
         PacketEntity packetEntity = createPacketEntity();
 
-        assertThatThrownBy(() -> handler.handle(packetJson, packetEntity))
+        assertThatThrownBy(() -> handler.handle(packetJson, packetEntity, null))
                 .isInstanceOf(IllegalArgumentException.class)
                 .hasMessageContaining("'PersonID' must not be empty");
     }
@@ -124,7 +128,7 @@ class DataProjectCreateHandlerTest {
         JsonNode packetJson = createValidPacketJson();
         PacketEntity packetEntity = createPacketEntity();
 
-        handler.handle(packetJson, packetEntity);
+        handler.handle(packetJson, packetEntity, null);
 
         verify(personService, never()).persistDnsForPerson(any(), any());
         //noinspection unchecked
@@ -136,7 +140,7 @@ class DataProjectCreateHandlerTest {
         JsonNode packetJson = createPacketJsonWithDnList();
         PacketEntity packetEntity = createPacketEntity();
 
-        handler.handle(packetJson, packetEntity);
+        handler.handle(packetJson, packetEntity, null);
 
         ArgumentCaptor<String> personIdCaptor = ArgumentCaptor.forClass(String.class);
         ArgumentCaptor<JsonNode> dnListCaptor = ArgumentCaptor.forClass(JsonNode.class);
@@ -158,7 +162,7 @@ class DataProjectCreateHandlerTest {
         packetEntity.setAmieId(233497909L);
         packetEntity.setType("data_project_create");
 
-        handler.handle(incomingPacket, packetEntity);
+        handler.handle(incomingPacket, packetEntity, null);
 
         ArgumentCaptor<JsonNode> dnListCaptor = ArgumentCaptor.forClass(JsonNode.class);
         verify(personService).persistDnsForPerson(eq("test-person-456"), dnListCaptor.capture());

--- a/allocations/access-ci-service/src/test/java/org/apache/custos/access/ci/service/handler/amie/DataProjectCreateHandlerTest.java
+++ b/allocations/access-ci-service/src/test/java/org/apache/custos/access/ci/service/handler/amie/DataProjectCreateHandlerTest.java
@@ -23,6 +23,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import org.apache.custos.access.ci.service.client.amie.AmieClient;
 import org.apache.custos.access.ci.service.model.amie.PacketEntity;
+import org.apache.custos.access.ci.service.service.PersonService;
 import org.apache.custos.access.ci.service.util.JsonTestUtils;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Tag;
@@ -38,6 +39,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 
 @ExtendWith(MockitoExtension.class)
@@ -47,12 +49,15 @@ class DataProjectCreateHandlerTest {
     @Mock
     private AmieClient amieClient;
 
+    @Mock
+    private PersonService personService;
+
     private DataProjectCreateHandler handler;
     private ObjectMapper objectMapper;
 
     @BeforeEach
     void setUp() {
-        handler = new DataProjectCreateHandler(amieClient);
+        handler = new DataProjectCreateHandler(amieClient, personService);
         objectMapper = new ObjectMapper();
     }
 
@@ -115,25 +120,49 @@ class DataProjectCreateHandlerTest {
     }
 
     @Test
-    void handle_withEmptyDnList_shouldProcessSuccessfully() {
+    void handle_withEmptyDnList_shouldNotCallPersonServiceAndSendReply() {
         JsonNode packetJson = createValidPacketJson();
         PacketEntity packetEntity = createPacketEntity();
 
         handler.handle(packetJson, packetEntity);
+
+        verify(personService, never()).persistDnsForPerson(any(), any());
+        //noinspection unchecked
+        verify(amieClient).replyToPacket(eq(12345L), any(Map.class));
+    }
+
+    @Test
+    void handle_withNonEmptyDnList_shouldPersistDnsAndSendReply() {
+        JsonNode packetJson = createPacketJsonWithDnList();
+        PacketEntity packetEntity = createPacketEntity();
+
+        handler.handle(packetJson, packetEntity);
+
+        ArgumentCaptor<String> personIdCaptor = ArgumentCaptor.forClass(String.class);
+        ArgumentCaptor<JsonNode> dnListCaptor = ArgumentCaptor.forClass(JsonNode.class);
+        verify(personService).persistDnsForPerson(personIdCaptor.capture(), dnListCaptor.capture());
+
+        assertThat(personIdCaptor.getValue()).isEqualTo("person-123");
+        assertThat(dnListCaptor.getValue().isArray()).isTrue();
+        assertThat(dnListCaptor.getValue().size()).isEqualTo(2);
 
         //noinspection unchecked
         verify(amieClient).replyToPacket(eq(12345L), any(Map.class));
     }
 
     @Test
-    void handle_withNonEmptyDnList_shouldProcessSuccessfully() {
-        JsonNode packetJson = createPacketJsonWithDnList();
-        PacketEntity packetEntity = createPacketEntity();
+    void handle_withValidPacketContainingDnList_shouldPersistAllDns() {
+        JsonNode incomingPacket = JsonTestUtils.loadMockPacket("data_project_create", "incoming-data.json");
 
-        handler.handle(packetJson, packetEntity);
+        PacketEntity packetEntity = new PacketEntity();
+        packetEntity.setAmieId(233497909L);
+        packetEntity.setType("data_project_create");
 
-        //noinspection unchecked
-        verify(amieClient).replyToPacket(eq(12345L), any(Map.class));
+        handler.handle(incomingPacket, packetEntity);
+
+        ArgumentCaptor<JsonNode> dnListCaptor = ArgumentCaptor.forClass(JsonNode.class);
+        verify(personService).persistDnsForPerson(eq("test-person-456"), dnListCaptor.capture());
+        assertThat(dnListCaptor.getValue().size()).isEqualTo(3);
     }
 
     private JsonNode createValidPacketJson() {

--- a/allocations/access-ci-service/src/test/java/org/apache/custos/access/ci/service/handler/amie/InformTransactionCompleteHandlerTest.java
+++ b/allocations/access-ci-service/src/test/java/org/apache/custos/access/ci/service/handler/amie/InformTransactionCompleteHandlerTest.java
@@ -21,11 +21,13 @@ package org.apache.custos.access.ci.service.handler.amie;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.apache.custos.access.ci.service.model.amie.PacketEntity;
+import org.apache.custos.access.ci.service.service.AuditService;
 import org.apache.custos.access.ci.service.util.JsonTestUtils;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -35,12 +37,15 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 @Tag("unit")
 class InformTransactionCompleteHandlerTest {
 
+    @Mock
+    private AuditService auditService;
+
     private InformTransactionCompleteHandler handler;
     private ObjectMapper objectMapper;
 
     @BeforeEach
     void setUp() {
-        handler = new InformTransactionCompleteHandler();
+        handler = new InformTransactionCompleteHandler(auditService);
         objectMapper = new ObjectMapper();
     }
 
@@ -57,7 +62,7 @@ class InformTransactionCompleteHandlerTest {
         packetEntity.setAmieId(233497913L);
         packetEntity.setType("inform_transaction_complete");
 
-        handler.handle(incomingPacket, packetEntity);
+        handler.handle(incomingPacket, packetEntity, null);
     }
 
     @Test
@@ -65,7 +70,7 @@ class InformTransactionCompleteHandlerTest {
         JsonNode packetJson = createMinimalPacketJson();
         PacketEntity packetEntity = createPacketEntity();
 
-        handler.handle(packetJson, packetEntity);
+        handler.handle(packetJson, packetEntity, null);
     }
 
     @Test
@@ -73,7 +78,7 @@ class InformTransactionCompleteHandlerTest {
         PacketEntity packetEntity = createPacketEntity();
 
         //noinspection DataFlowIssue
-        assertThatThrownBy(() -> handler.handle(null, packetEntity)).isInstanceOf(NullPointerException.class);
+        assertThatThrownBy(() -> handler.handle(null, packetEntity, null)).isInstanceOf(NullPointerException.class);
     }
 
     @Test
@@ -81,7 +86,7 @@ class InformTransactionCompleteHandlerTest {
         JsonNode packetJson = createValidPacketJson();
 
         //noinspection DataFlowIssue
-        assertThatThrownBy(() -> handler.handle(packetJson, null)).isInstanceOf(NullPointerException.class);
+        assertThatThrownBy(() -> handler.handle(packetJson, null, null)).isInstanceOf(NullPointerException.class);
     }
 
     private JsonNode createValidPacketJson() {

--- a/allocations/access-ci-service/src/test/java/org/apache/custos/access/ci/service/handler/amie/NoOpHandlerTest.java
+++ b/allocations/access-ci-service/src/test/java/org/apache/custos/access/ci/service/handler/amie/NoOpHandlerTest.java
@@ -55,7 +55,7 @@ class NoOpHandlerTest {
         packetEntity.setAmieId(12345L);
         packetEntity.setType("unknown_type");
 
-        handler.handle(packetJson, packetEntity);
+        handler.handle(packetJson, packetEntity, null);
     }
 
     @Test
@@ -64,7 +64,7 @@ class NoOpHandlerTest {
         packetEntity.setAmieId(12345L);
         packetEntity.setType("unknown_type");
 
-        handler.handle(null, packetEntity);
+        handler.handle(null, packetEntity, null);
     }
 
     @Test
@@ -72,6 +72,6 @@ class NoOpHandlerTest {
         JsonNode packetJson = objectMapper.createObjectNode();
 
         //noinspection DataFlowIssue
-        assertThatThrownBy(() -> handler.handle(packetJson, null)).isInstanceOf(NullPointerException.class);
+        assertThatThrownBy(() -> handler.handle(packetJson, null, null)).isInstanceOf(NullPointerException.class);
     }
 }

--- a/allocations/access-ci-service/src/test/java/org/apache/custos/access/ci/service/handler/amie/PacketRouterTest.java
+++ b/allocations/access-ci-service/src/test/java/org/apache/custos/access/ci/service/handler/amie/PacketRouterTest.java
@@ -63,10 +63,10 @@ class PacketRouterTest {
         PacketEntity packetEntity = new PacketEntity();
         packetEntity.setType("request_project_create");
 
-        router.route(packetJson, packetEntity);
+        router.route(packetJson, packetEntity, null);
 
-        verify(mockHandler1).handle(packetJson, packetEntity);
-        verify(mockHandler2, never()).handle(any(), any());
+        verify(mockHandler1).handle(packetJson, packetEntity, null);
+        verify(mockHandler2, never()).handle(any(), any(), any());
     }
 
     @Test
@@ -75,10 +75,10 @@ class PacketRouterTest {
         PacketEntity packetEntity = new PacketEntity();
         packetEntity.setType("request_account_create");
 
-        router.route(packetJson, packetEntity);
+        router.route(packetJson, packetEntity, null);
 
-        verify(mockHandler2).handle(packetJson, packetEntity);
-        verify(mockHandler1, never()).handle(any(), any());
+        verify(mockHandler2).handle(packetJson, packetEntity, null);
+        verify(mockHandler1, never()).handle(any(), any(), any());
     }
 
     @Test
@@ -87,10 +87,10 @@ class PacketRouterTest {
         PacketEntity packetEntity = new PacketEntity();
         packetEntity.setType("unknown_packet_type");
 
-        router.route(packetJson, packetEntity);
+        router.route(packetJson, packetEntity, null);
 
-        verify(mockHandler1, never()).handle(any(), any());
-        verify(mockHandler2, never()).handle(any(), any());
+        verify(mockHandler1, never()).handle(any(), any(), any());
+        verify(mockHandler2, never()).handle(any(), any(), any());
     }
 
     @Test
@@ -100,9 +100,9 @@ class PacketRouterTest {
         PacketEntity packetEntity = new PacketEntity();
         packetEntity.setType("REQUEST_PROJECT_CREATE");
 
-        router.route(packetJson, packetEntity);
+        router.route(packetJson, packetEntity, null);
 
-        verify(mockHandler1).handle(packetJson, packetEntity);
-        verify(mockHandler2, never()).handle(any(), any());
+        verify(mockHandler1).handle(packetJson, packetEntity, null);
+        verify(mockHandler2, never()).handle(any(), any(), any());
     }
 }

--- a/allocations/access-ci-service/src/test/java/org/apache/custos/access/ci/service/handler/amie/RequestAccountCreateHandlerTest.java
+++ b/allocations/access-ci-service/src/test/java/org/apache/custos/access/ci/service/handler/amie/RequestAccountCreateHandlerTest.java
@@ -24,6 +24,7 @@ import org.apache.custos.access.ci.service.client.amie.AmieClient;
 import org.apache.custos.access.ci.service.model.ClusterAccountEntity;
 import org.apache.custos.access.ci.service.model.PersonEntity;
 import org.apache.custos.access.ci.service.model.amie.PacketEntity;
+import org.apache.custos.access.ci.service.service.AuditService;
 import org.apache.custos.access.ci.service.service.PersonService;
 import org.apache.custos.access.ci.service.service.ProjectMembershipService;
 import org.apache.custos.access.ci.service.service.ProjectService;
@@ -65,12 +66,15 @@ class RequestAccountCreateHandlerTest {
     @Mock
     private ProjectMembershipService membershipService;
 
+    @Mock
+    private AuditService auditService;
+
     private RequestAccountCreateHandler handler;
     private ObjectMapper objectMapper;
 
     @BeforeEach
     void setUp() {
-        handler = new RequestAccountCreateHandler(amieClient, personService, userAccountService, projectService, membershipService);
+        handler = new RequestAccountCreateHandler(amieClient, personService, userAccountService, projectService, membershipService, auditService);
         objectMapper = new ObjectMapper();
     }
 
@@ -93,7 +97,7 @@ class RequestAccountCreateHandlerTest {
         when(personService.findOrCreatePersonFromPacket(any(JsonNode.class))).thenReturn(personEntity);
         when(userAccountService.provisionClusterAccount(personEntity)).thenReturn(createClusterAccount());
 
-        handler.handle(incomingPacket, packetEntity);
+        handler.handle(incomingPacket, packetEntity, null);
 
         verify(personService).findOrCreatePersonFromPacket(any(JsonNode.class));
         verify(userAccountService).provisionClusterAccount(personEntity);
@@ -130,7 +134,7 @@ class RequestAccountCreateHandlerTest {
         JsonNode packetJson = createPacketJsonWithMissingField("ProjectID");
         PacketEntity packetEntity = createPacketEntity();
 
-        assertThatThrownBy(() -> handler.handle(packetJson, packetEntity))
+        assertThatThrownBy(() -> handler.handle(packetJson, packetEntity, null))
                 .isInstanceOf(IllegalArgumentException.class)
                 .hasMessageContaining("'ProjectID' (the local project ID) must not be empty");
     }
@@ -140,7 +144,7 @@ class RequestAccountCreateHandlerTest {
         JsonNode packetJson = createPacketJsonWithMissingField("GrantNumber");
         PacketEntity packetEntity = createPacketEntity();
 
-        assertThatThrownBy(() -> handler.handle(packetJson, packetEntity))
+        assertThatThrownBy(() -> handler.handle(packetJson, packetEntity, null))
                 .isInstanceOf(IllegalArgumentException.class)
                 .hasMessageContaining("'GrantNumber' must not be empty");
     }
@@ -150,7 +154,7 @@ class RequestAccountCreateHandlerTest {
         JsonNode packetJson = createPacketJsonWithMissingField("UserGlobalID");
         PacketEntity packetEntity = createPacketEntity();
 
-        assertThatThrownBy(() -> handler.handle(packetJson, packetEntity))
+        assertThatThrownBy(() -> handler.handle(packetJson, packetEntity, null))
                 .isInstanceOf(IllegalArgumentException.class)
                 .hasMessageContaining("'UserGlobalID' must not be empty");
     }

--- a/allocations/access-ci-service/src/test/java/org/apache/custos/access/ci/service/handler/amie/RequestAccountInactivateHandlerTest.java
+++ b/allocations/access-ci-service/src/test/java/org/apache/custos/access/ci/service/handler/amie/RequestAccountInactivateHandlerTest.java
@@ -23,6 +23,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import org.apache.custos.access.ci.service.client.amie.AmieClient;
 import org.apache.custos.access.ci.service.model.amie.PacketEntity;
+import org.apache.custos.access.ci.service.service.AuditService;
 import org.apache.custos.access.ci.service.service.ProjectMembershipService;
 import org.apache.custos.access.ci.service.util.JsonTestUtils;
 import org.junit.jupiter.api.BeforeEach;
@@ -51,12 +52,15 @@ class RequestAccountInactivateHandlerTest {
     @Mock
     private ProjectMembershipService membershipService;
 
+    @Mock
+    private AuditService auditService;
+
     private RequestAccountInactivateHandler handler;
     private ObjectMapper objectMapper;
 
     @BeforeEach
     void setUp() {
-        handler = new RequestAccountInactivateHandler(amieClient, membershipService);
+        handler = new RequestAccountInactivateHandler(amieClient, membershipService, auditService);
         objectMapper = new ObjectMapper();
     }
 
@@ -74,7 +78,7 @@ class RequestAccountInactivateHandlerTest {
         packetEntity.setAmieId(233497919L);
         packetEntity.setType("request_account_inactivate");
 
-        handler.handle(incomingPacket, packetEntity);
+        handler.handle(incomingPacket, packetEntity, null);
 
         verify(membershipService).inactivateMembershipsByPersonAndProject("test-project-456", "test-user-person-123");
 
@@ -104,7 +108,7 @@ class RequestAccountInactivateHandlerTest {
         JsonNode packetJson = createPacketJsonWithMissingField("ProjectID");
         PacketEntity packetEntity = createPacketEntity();
 
-        assertThatThrownBy(() -> handler.handle(packetJson, packetEntity))
+        assertThatThrownBy(() -> handler.handle(packetJson, packetEntity, null))
                 .isInstanceOf(IllegalArgumentException.class)
                 .hasMessageContaining("'ProjectID' must not be empty");
     }
@@ -114,7 +118,7 @@ class RequestAccountInactivateHandlerTest {
         JsonNode packetJson = createPacketJsonWithMissingField("PersonID");
         PacketEntity packetEntity = createPacketEntity();
 
-        assertThatThrownBy(() -> handler.handle(packetJson, packetEntity))
+        assertThatThrownBy(() -> handler.handle(packetJson, packetEntity, null))
                 .isInstanceOf(IllegalArgumentException.class)
                 .hasMessageContaining("'PersonID' must not be empty");
     }
@@ -124,7 +128,7 @@ class RequestAccountInactivateHandlerTest {
         JsonNode packetJson = createPacketJsonWithEmptyField("ProjectID");
         PacketEntity packetEntity = createPacketEntity();
 
-        assertThatThrownBy(() -> handler.handle(packetJson, packetEntity))
+        assertThatThrownBy(() -> handler.handle(packetJson, packetEntity, null))
                 .isInstanceOf(IllegalArgumentException.class)
                 .hasMessageContaining("'ProjectID' must not be empty");
     }
@@ -134,7 +138,7 @@ class RequestAccountInactivateHandlerTest {
         JsonNode packetJson = createPacketJsonWithEmptyField("PersonID");
         PacketEntity packetEntity = createPacketEntity();
 
-        assertThatThrownBy(() -> handler.handle(packetJson, packetEntity))
+        assertThatThrownBy(() -> handler.handle(packetJson, packetEntity, null))
                 .isInstanceOf(IllegalArgumentException.class)
                 .hasMessageContaining("'PersonID' must not be empty");
     }
@@ -144,7 +148,7 @@ class RequestAccountInactivateHandlerTest {
         JsonNode packetJson = createPacketJsonWithResourceList();
         PacketEntity packetEntity = createPacketEntity();
 
-        handler.handle(packetJson, packetEntity);
+        handler.handle(packetJson, packetEntity, null);
 
         verify(membershipService).inactivateMembershipsByPersonAndProject("PRJ-TEST123", "person-123");
         //noinspection unchecked

--- a/allocations/access-ci-service/src/test/java/org/apache/custos/access/ci/service/handler/amie/RequestAccountReactivateHandlerTest.java
+++ b/allocations/access-ci-service/src/test/java/org/apache/custos/access/ci/service/handler/amie/RequestAccountReactivateHandlerTest.java
@@ -22,6 +22,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import org.apache.custos.access.ci.service.client.amie.AmieClient;
 import org.apache.custos.access.ci.service.model.amie.PacketEntity;
+import org.apache.custos.access.ci.service.service.AuditService;
 import org.apache.custos.access.ci.service.service.ProjectMembershipService;
 import org.apache.custos.access.ci.service.util.JsonTestUtils;
 import org.junit.jupiter.api.BeforeEach;
@@ -50,12 +51,15 @@ class RequestAccountReactivateHandlerTest {
     @Mock
     private ProjectMembershipService membershipService;
 
+    @Mock
+    private AuditService auditService;
+
     private RequestAccountReactivateHandler handler;
     private ObjectMapper objectMapper;
 
     @BeforeEach
     void setUp() {
-        handler = new RequestAccountReactivateHandler(amieClient, membershipService);
+        handler = new RequestAccountReactivateHandler(amieClient, membershipService, auditService);
         objectMapper = new ObjectMapper();
     }
 
@@ -73,7 +77,7 @@ class RequestAccountReactivateHandlerTest {
         packetEntity.setAmieId(233497923L);
         packetEntity.setType("request_account_reactivate");
 
-        handler.handle(incomingPacket, packetEntity);
+        handler.handle(incomingPacket, packetEntity, null);
 
         verify(membershipService).reactivateMembershipsByPersonAndProject("test-project-456", "test-user-person-123");
 
@@ -103,7 +107,7 @@ class RequestAccountReactivateHandlerTest {
         JsonNode packetJson = createPacketJsonWithMissingField("ProjectID");
         PacketEntity packetEntity = createPacketEntity();
 
-        assertThatThrownBy(() -> handler.handle(packetJson, packetEntity))
+        assertThatThrownBy(() -> handler.handle(packetJson, packetEntity, null))
                 .isInstanceOf(IllegalArgumentException.class)
                 .hasMessageContaining("'ProjectID' must not be empty");
     }
@@ -113,7 +117,7 @@ class RequestAccountReactivateHandlerTest {
         JsonNode packetJson = createPacketJsonWithMissingField("PersonID");
         PacketEntity packetEntity = createPacketEntity();
 
-        assertThatThrownBy(() -> handler.handle(packetJson, packetEntity))
+        assertThatThrownBy(() -> handler.handle(packetJson, packetEntity, null))
                 .isInstanceOf(IllegalArgumentException.class)
                 .hasMessageContaining("'PersonID' must not be empty");
     }
@@ -123,7 +127,7 @@ class RequestAccountReactivateHandlerTest {
         JsonNode packetJson = createValidPacketJson();
         PacketEntity packetEntity = createPacketEntity();
 
-        handler.handle(packetJson, packetEntity);
+        handler.handle(packetJson, packetEntity, null);
 
         verify(membershipService).reactivateMembershipsByPersonAndProject("test-project-456", "test-user-person-123");
         verify(amieClient).replyToPacket(eq(12345L), any(Map.class));
@@ -134,7 +138,7 @@ class RequestAccountReactivateHandlerTest {
         JsonNode packetJson = createPacketJsonWithResourceList();
         PacketEntity packetEntity = createPacketEntity();
 
-        handler.handle(packetJson, packetEntity);
+        handler.handle(packetJson, packetEntity, null);
 
         verify(membershipService).reactivateMembershipsByPersonAndProject("test-project-456", "test-user-person-123");
         verify(amieClient).replyToPacket(eq(12345L), any(Map.class));

--- a/allocations/access-ci-service/src/test/java/org/apache/custos/access/ci/service/handler/amie/RequestPersonMergeHandlerTest.java
+++ b/allocations/access-ci-service/src/test/java/org/apache/custos/access/ci/service/handler/amie/RequestPersonMergeHandlerTest.java
@@ -23,6 +23,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import org.apache.custos.access.ci.service.client.amie.AmieClient;
 import org.apache.custos.access.ci.service.model.amie.PacketEntity;
+import org.apache.custos.access.ci.service.service.AuditService;
 import org.apache.custos.access.ci.service.service.PersonService;
 import org.apache.custos.access.ci.service.util.JsonTestUtils;
 import org.junit.jupiter.api.BeforeEach;
@@ -51,12 +52,15 @@ class RequestPersonMergeHandlerTest {
     @Mock
     private PersonService personService;
 
+    @Mock
+    private AuditService auditService;
+
     private RequestPersonMergeHandler handler;
     private ObjectMapper objectMapper;
 
     @BeforeEach
     void setUp() {
-        handler = new RequestPersonMergeHandler(amieClient, personService);
+        handler = new RequestPersonMergeHandler(amieClient, personService, auditService);
         objectMapper = new ObjectMapper();
     }
 
@@ -74,7 +78,7 @@ class RequestPersonMergeHandlerTest {
         packetEntity.setAmieId(233497920L);
         packetEntity.setType("request_person_merge");
 
-        handler.handle(incomingPacket, packetEntity);
+        handler.handle(incomingPacket, packetEntity, null);
 
         verify(personService).mergePersons("test-person-primary-123", "test-person-secondary-456");
 
@@ -105,7 +109,7 @@ class RequestPersonMergeHandlerTest {
         JsonNode packetJson = createPacketJsonWithMissingField("KeepPersonID");
         PacketEntity packetEntity = createPacketEntity();
 
-        assertThatThrownBy(() -> handler.handle(packetJson, packetEntity))
+        assertThatThrownBy(() -> handler.handle(packetJson, packetEntity, null))
                 .isInstanceOf(IllegalArgumentException.class)
                 .hasMessageContaining("'KeepPersonID' (the surviving user's local ID) must not be empty");
     }
@@ -115,7 +119,7 @@ class RequestPersonMergeHandlerTest {
         JsonNode packetJson = createPacketJsonWithMissingField("DeletePersonID");
         PacketEntity packetEntity = createPacketEntity();
 
-        assertThatThrownBy(() -> handler.handle(packetJson, packetEntity))
+        assertThatThrownBy(() -> handler.handle(packetJson, packetEntity, null))
                 .isInstanceOf(IllegalArgumentException.class)
                 .hasMessageContaining("'DeletePersonID' (the retiring user's local ID) must not be empty");
     }
@@ -125,7 +129,7 @@ class RequestPersonMergeHandlerTest {
         JsonNode packetJson = createPacketJsonWithEmptyField("KeepPersonID");
         PacketEntity packetEntity = createPacketEntity();
 
-        assertThatThrownBy(() -> handler.handle(packetJson, packetEntity))
+        assertThatThrownBy(() -> handler.handle(packetJson, packetEntity, null))
                 .isInstanceOf(IllegalArgumentException.class)
                 .hasMessageContaining("'KeepPersonID' (the surviving user's local ID) must not be empty");
     }
@@ -135,7 +139,7 @@ class RequestPersonMergeHandlerTest {
         JsonNode packetJson = createPacketJsonWithEmptyField("DeletePersonID");
         PacketEntity packetEntity = createPacketEntity();
 
-        assertThatThrownBy(() -> handler.handle(packetJson, packetEntity))
+        assertThatThrownBy(() -> handler.handle(packetJson, packetEntity, null))
                 .isInstanceOf(IllegalArgumentException.class)
                 .hasMessageContaining("'DeletePersonID' (the retiring user's local ID) must not be empty");
     }
@@ -145,7 +149,7 @@ class RequestPersonMergeHandlerTest {
         JsonNode packetJson = createPacketJsonWithGlobalIds();
         PacketEntity packetEntity = createPacketEntity();
 
-        handler.handle(packetJson, packetEntity);
+        handler.handle(packetJson, packetEntity, null);
 
         verify(personService).mergePersons("person-surviving", "person-retiring");
         //noinspection unchecked

--- a/allocations/access-ci-service/src/test/java/org/apache/custos/access/ci/service/handler/amie/RequestProjectCreateHandlerTest.java
+++ b/allocations/access-ci-service/src/test/java/org/apache/custos/access/ci/service/handler/amie/RequestProjectCreateHandlerTest.java
@@ -26,6 +26,7 @@ import org.apache.custos.access.ci.service.model.ClusterAccountEntity;
 import org.apache.custos.access.ci.service.model.PersonEntity;
 import org.apache.custos.access.ci.service.model.ProjectEntity;
 import org.apache.custos.access.ci.service.model.amie.PacketEntity;
+import org.apache.custos.access.ci.service.service.AuditService;
 import org.apache.custos.access.ci.service.service.PersonService;
 import org.apache.custos.access.ci.service.service.ProjectMembershipService;
 import org.apache.custos.access.ci.service.service.ProjectService;
@@ -68,12 +69,15 @@ class RequestProjectCreateHandlerTest {
     @Mock
     private ProjectMembershipService membershipService;
 
+    @Mock
+    private AuditService auditService;
+
     private RequestProjectCreateHandler handler;
     private ObjectMapper objectMapper;
 
     @BeforeEach
     void setUp() {
-        handler = new RequestProjectCreateHandler(amieClient, personService, userAccountService, projectService, membershipService);
+        handler = new RequestProjectCreateHandler(amieClient, personService, userAccountService, projectService, membershipService, auditService);
         objectMapper = new ObjectMapper();
     }
 
@@ -98,7 +102,7 @@ class RequestProjectCreateHandlerTest {
         when(userAccountService.provisionClusterAccount(personEntity)).thenReturn(createClusterAccount());
         when(projectService.createOrFindProject(anyString(), anyString())).thenReturn(projectEntity);
 
-        handler.handle(incomingPacket, packetEntity);
+        handler.handle(incomingPacket, packetEntity, null);
         verify(personService).findOrCreatePersonFromPacket(any(JsonNode.class));
         verify(userAccountService).provisionClusterAccount(personEntity);
         verify(projectService).createOrFindProject(anyString(), anyString());
@@ -134,7 +138,7 @@ class RequestProjectCreateHandlerTest {
     void handle_withNullPacketJson_shouldThrowException() {
         PacketEntity packetEntity = createPacketEntity();
 
-        assertThatThrownBy(() -> handler.handle(null, packetEntity))
+        assertThatThrownBy(() -> handler.handle(null, packetEntity, null))
                 .isInstanceOf(IllegalArgumentException.class)
                 .hasMessage("packetJson is null");
     }
@@ -144,7 +148,7 @@ class RequestProjectCreateHandlerTest {
         JsonNode packetJson = objectMapper.createObjectNode();
         PacketEntity packetEntity = createPacketEntity();
 
-        assertThatThrownBy(() -> handler.handle(packetJson, packetEntity))
+        assertThatThrownBy(() -> handler.handle(packetJson, packetEntity, null))
                 .isInstanceOf(IllegalArgumentException.class)
                 .hasMessage("packetJson.body is missing");
     }
@@ -154,7 +158,7 @@ class RequestProjectCreateHandlerTest {
         JsonNode packetJson = createPacketJsonWithMissingField("GrantNumber");
         PacketEntity packetEntity = createPacketEntity();
 
-        assertThatThrownBy(() -> handler.handle(packetJson, packetEntity))
+        assertThatThrownBy(() -> handler.handle(packetJson, packetEntity, null))
                 .isInstanceOf(IllegalArgumentException.class)
                 .hasMessageContaining("'GrantNumber' must not be empty");
     }
@@ -164,7 +168,7 @@ class RequestProjectCreateHandlerTest {
         JsonNode packetJson = createPacketJsonWithMissingField("PiGlobalID");
         PacketEntity packetEntity = createPacketEntity();
 
-        assertThatThrownBy(() -> handler.handle(packetJson, packetEntity))
+        assertThatThrownBy(() -> handler.handle(packetJson, packetEntity, null))
                 .isInstanceOf(IllegalArgumentException.class)
                 .hasMessageContaining("'PiGlobalID' must not be empty");
     }

--- a/allocations/access-ci-service/src/test/java/org/apache/custos/access/ci/service/handler/amie/RequestProjectInactivateHandlerTest.java
+++ b/allocations/access-ci-service/src/test/java/org/apache/custos/access/ci/service/handler/amie/RequestProjectInactivateHandlerTest.java
@@ -23,6 +23,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import org.apache.custos.access.ci.service.client.amie.AmieClient;
 import org.apache.custos.access.ci.service.model.amie.PacketEntity;
+import org.apache.custos.access.ci.service.service.AuditService;
 import org.apache.custos.access.ci.service.service.ProjectMembershipService;
 import org.apache.custos.access.ci.service.service.ProjectService;
 import org.apache.custos.access.ci.service.util.JsonTestUtils;
@@ -55,12 +56,15 @@ class RequestProjectInactivateHandlerTest {
     @Mock
     private ProjectMembershipService membershipService;
 
+    @Mock
+    private AuditService auditService;
+
     private RequestProjectInactivateHandler handler;
     private ObjectMapper objectMapper;
 
     @BeforeEach
     void setUp() {
-        handler = new RequestProjectInactivateHandler(amieClient, projectService, membershipService);
+        handler = new RequestProjectInactivateHandler(amieClient, projectService, membershipService, auditService);
         objectMapper = new ObjectMapper();
     }
 
@@ -78,7 +82,7 @@ class RequestProjectInactivateHandlerTest {
         packetEntity.setAmieId(233497911L);
         packetEntity.setType("request_project_inactivate");
 
-        handler.handle(incomingPacket, packetEntity);
+        handler.handle(incomingPacket, packetEntity, null);
 
         verify(projectService).inactivateProject("test-project-123");
         verify(membershipService).inactivateAllMembershipsForProject("test-project-123");
@@ -109,7 +113,7 @@ class RequestProjectInactivateHandlerTest {
         JsonNode packetJson = createPacketJsonWithMissingProjectIdField();
         PacketEntity packetEntity = createPacketEntity();
 
-        assertThatThrownBy(() -> handler.handle(packetJson, packetEntity))
+        assertThatThrownBy(() -> handler.handle(packetJson, packetEntity, null))
                 .isInstanceOf(IllegalArgumentException.class)
                 .hasMessageContaining("'ProjectID' must not be empty");
     }
@@ -119,7 +123,7 @@ class RequestProjectInactivateHandlerTest {
         JsonNode packetJson = createPacketJsonWithEmptyField("ProjectID");
         PacketEntity packetEntity = createPacketEntity();
 
-        assertThatThrownBy(() -> handler.handle(packetJson, packetEntity))
+        assertThatThrownBy(() -> handler.handle(packetJson, packetEntity, null))
                 .isInstanceOf(IllegalArgumentException.class)
                 .hasMessageContaining("'ProjectID' must not be empty");
     }
@@ -129,7 +133,7 @@ class RequestProjectInactivateHandlerTest {
         JsonNode packetJson = createPacketJsonWithOptionalFields();
         PacketEntity packetEntity = createPacketEntity();
 
-        handler.handle(packetJson, packetEntity);
+        handler.handle(packetJson, packetEntity, null);
 
         verify(projectService).inactivateProject("PRJ-TEST123");
         verify(membershipService).inactivateAllMembershipsForProject("PRJ-TEST123");

--- a/allocations/access-ci-service/src/test/java/org/apache/custos/access/ci/service/handler/amie/RequestProjectReactivateHandlerTest.java
+++ b/allocations/access-ci-service/src/test/java/org/apache/custos/access/ci/service/handler/amie/RequestProjectReactivateHandlerTest.java
@@ -23,6 +23,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import org.apache.custos.access.ci.service.client.amie.AmieClient;
 import org.apache.custos.access.ci.service.model.amie.PacketEntity;
+import org.apache.custos.access.ci.service.service.AuditService;
 import org.apache.custos.access.ci.service.service.ProjectMembershipService;
 import org.apache.custos.access.ci.service.service.ProjectService;
 import org.apache.custos.access.ci.service.util.JsonTestUtils;
@@ -55,12 +56,15 @@ class RequestProjectReactivateHandlerTest {
     @Mock
     private ProjectMembershipService membershipService;
 
+    @Mock
+    private AuditService auditService;
+
     private RequestProjectReactivateHandler handler;
     private ObjectMapper objectMapper;
 
     @BeforeEach
     void setUp() {
-        handler = new RequestProjectReactivateHandler(amieClient, projectService, membershipService);
+        handler = new RequestProjectReactivateHandler(amieClient, projectService, membershipService, auditService);
         objectMapper = new ObjectMapper();
     }
 
@@ -78,7 +82,7 @@ class RequestProjectReactivateHandlerTest {
         packetEntity.setAmieId(233497914L);
         packetEntity.setType("request_project_reactivate");
 
-        handler.handle(incomingPacket, packetEntity);
+        handler.handle(incomingPacket, packetEntity, null);
 
         verify(projectService).reactivateProject("test-project-123");
         verify(membershipService).reactivatePiMembership("test-project-123");
@@ -109,7 +113,7 @@ class RequestProjectReactivateHandlerTest {
         JsonNode packetJson = createPacketJsonWithMissingProjectIdField();
         PacketEntity packetEntity = createPacketEntity();
 
-        assertThatThrownBy(() -> handler.handle(packetJson, packetEntity))
+        assertThatThrownBy(() -> handler.handle(packetJson, packetEntity, null))
                 .isInstanceOf(IllegalArgumentException.class)
                 .hasMessageContaining("'ProjectID' must not be empty");
     }
@@ -119,7 +123,7 @@ class RequestProjectReactivateHandlerTest {
         JsonNode packetJson = createPacketJsonWithEmptyField("ProjectID");
         PacketEntity packetEntity = createPacketEntity();
 
-        assertThatThrownBy(() -> handler.handle(packetJson, packetEntity))
+        assertThatThrownBy(() -> handler.handle(packetJson, packetEntity, null))
                 .isInstanceOf(IllegalArgumentException.class)
                 .hasMessageContaining("'ProjectID' must not be empty");
     }
@@ -129,7 +133,7 @@ class RequestProjectReactivateHandlerTest {
         JsonNode packetJson = createPacketJsonWithOptionalFields();
         PacketEntity packetEntity = createPacketEntity();
 
-        handler.handle(packetJson, packetEntity);
+        handler.handle(packetJson, packetEntity, null);
 
         verify(projectService).reactivateProject("PRJ-TEST123");
         verify(membershipService).reactivatePiMembership("PRJ-TEST123");

--- a/allocations/access-ci-service/src/test/java/org/apache/custos/access/ci/service/handler/amie/RequestUserModifyHandlerTest.java
+++ b/allocations/access-ci-service/src/test/java/org/apache/custos/access/ci/service/handler/amie/RequestUserModifyHandlerTest.java
@@ -23,6 +23,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import org.apache.custos.access.ci.service.client.amie.AmieClient;
 import org.apache.custos.access.ci.service.model.amie.PacketEntity;
+import org.apache.custos.access.ci.service.service.AuditService;
 import org.apache.custos.access.ci.service.service.PersonService;
 import org.apache.custos.access.ci.service.util.JsonTestUtils;
 import org.junit.jupiter.api.BeforeEach;
@@ -51,12 +52,15 @@ class RequestUserModifyHandlerTest {
     @Mock
     private PersonService personService;
 
+    @Mock
+    private AuditService auditService;
+
     private RequestUserModifyHandler handler;
     private ObjectMapper objectMapper;
 
     @BeforeEach
     void setUp() {
-        handler = new RequestUserModifyHandler(amieClient, personService);
+        handler = new RequestUserModifyHandler(amieClient, personService, auditService);
         objectMapper = new ObjectMapper();
     }
 
@@ -74,7 +78,7 @@ class RequestUserModifyHandlerTest {
         packetEntity.setAmieId(233497921L);
         packetEntity.setType("request_user_modify");
 
-        handler.handle(incomingPacket, packetEntity);
+        handler.handle(incomingPacket, packetEntity, null);
 
         verify(personService).replaceFromModifyPacket(any(JsonNode.class));
 
@@ -109,7 +113,7 @@ class RequestUserModifyHandlerTest {
         packetEntity.setAmieId(233497922L);
         packetEntity.setType("request_user_modify");
 
-        handler.handle(incomingPacket, packetEntity);
+        handler.handle(incomingPacket, packetEntity, null);
 
         verify(personService).deleteFromModifyPacket(any(JsonNode.class));
 
@@ -140,7 +144,7 @@ class RequestUserModifyHandlerTest {
         JsonNode packetJson = createValidPacketJson("REPLACE");
         PacketEntity packetEntity = createPacketEntity();
 
-        handler.handle(packetJson, packetEntity);
+        handler.handle(packetJson, packetEntity, null);
 
         verify(personService).replaceFromModifyPacket(any(JsonNode.class));
         //noinspection unchecked
@@ -152,7 +156,7 @@ class RequestUserModifyHandlerTest {
         JsonNode packetJson = createPacketJsonWithMissingField("ActionType");
         PacketEntity packetEntity = createPacketEntity();
 
-        assertThatThrownBy(() -> handler.handle(packetJson, packetEntity))
+        assertThatThrownBy(() -> handler.handle(packetJson, packetEntity, null))
                 .isInstanceOf(IllegalArgumentException.class)
                 .hasMessageContaining("'ActionType' must not be empty (replace|delete)");
     }
@@ -162,7 +166,7 @@ class RequestUserModifyHandlerTest {
         JsonNode packetJson = createPacketJsonWithEmptyField("ActionType");
         PacketEntity packetEntity = createPacketEntity();
 
-        assertThatThrownBy(() -> handler.handle(packetJson, packetEntity))
+        assertThatThrownBy(() -> handler.handle(packetJson, packetEntity, null))
                 .isInstanceOf(IllegalArgumentException.class)
                 .hasMessageContaining("'ActionType' must not be empty (replace|delete)");
     }
@@ -172,7 +176,7 @@ class RequestUserModifyHandlerTest {
         JsonNode packetJson = createValidPacketJson("unsupported");
         PacketEntity packetEntity = createPacketEntity();
 
-        assertThatThrownBy(() -> handler.handle(packetJson, packetEntity))
+        assertThatThrownBy(() -> handler.handle(packetJson, packetEntity, null))
                 .isInstanceOf(IllegalArgumentException.class)
                 .hasMessageContaining("Unsupported ActionType: unsupported");
     }

--- a/allocations/access-ci-service/src/test/java/org/apache/custos/access/ci/service/metrics/AmieHealthIndicatorTest.java
+++ b/allocations/access-ci-service/src/test/java/org/apache/custos/access/ci/service/metrics/AmieHealthIndicatorTest.java
@@ -1,0 +1,118 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ */
+package org.apache.custos.access.ci.service.metrics;
+
+import org.apache.custos.access.ci.service.config.AmieProperties;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.boot.actuate.health.Health;
+import org.springframework.boot.actuate.health.Status;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.client.ResourceAccessException;
+import org.springframework.web.client.RestTemplate;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+@Tag("unit")
+class AmieHealthIndicatorTest {
+
+    private static final String BASE_URL = "https://a3mdev.xsede.org/amie-api-test";
+    private static final String SITE_CODE = "NEXUS";
+
+    @Mock
+    private RestTemplate restTemplate;
+
+    private AmieProperties amieProperties;
+    private AmieHealthIndicator healthIndicator;
+
+    @BeforeEach
+    void setUp() {
+        amieProperties = new AmieProperties();
+        amieProperties.setBaseUrl(BASE_URL);
+        amieProperties.setSiteCode(SITE_CODE);
+        healthIndicator = new AmieHealthIndicator(amieProperties, restTemplate);
+    }
+
+    @Test
+    void health_whenAmieApiReturns200_shouldBeUp() {
+        when(restTemplate.getForEntity(BASE_URL, String.class))
+                .thenReturn(ResponseEntity.ok("OK"));
+
+        Health health = healthIndicator.health();
+
+        assertThat(health.getStatus()).isEqualTo(Status.UP);
+        assertThat(health.getDetails()).containsEntry("url", BASE_URL);
+        assertThat(health.getDetails()).containsEntry("siteCode", SITE_CODE);
+        assertThat(health.getDetails()).containsEntry("httpStatus", 200);
+    }
+
+    @Test
+    void health_whenAmieApiReturns302_shouldBeUp() {
+        when(restTemplate.getForEntity(BASE_URL, String.class))
+                .thenReturn(ResponseEntity.status(HttpStatus.FOUND).build());
+
+        Health health = healthIndicator.health();
+
+        assertThat(health.getStatus()).isEqualTo(Status.UP);
+        assertThat(health.getDetails()).containsEntry("httpStatus", 302);
+    }
+
+    @Test
+    void health_whenAmieApiReturns500_shouldBeDown() {
+        when(restTemplate.getForEntity(BASE_URL, String.class))
+                .thenReturn(ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body("error"));
+
+        Health health = healthIndicator.health();
+
+        assertThat(health.getStatus()).isEqualTo(Status.DOWN);
+        assertThat(health.getDetails()).containsEntry("url", BASE_URL);
+        assertThat(health.getDetails()).containsEntry("httpStatus", 500);
+    }
+
+    @Test
+    void health_whenRestClientExceptionThrown_shouldBeDown() {
+        when(restTemplate.getForEntity(BASE_URL, String.class))
+                .thenThrow(new ResourceAccessException("Connection refused"));
+
+        Health health = healthIndicator.health();
+
+        assertThat(health.getStatus()).isEqualTo(Status.DOWN);
+        assertThat(health.getDetails()).containsEntry("url", BASE_URL);
+        assertThat(health.getDetails()).containsEntry("siteCode", SITE_CODE);
+    }
+
+    @Test
+    void health_whenNetworkTimeout_shouldIncludeUrlInDownDetails() {
+        when(restTemplate.getForEntity(BASE_URL, String.class))
+                .thenThrow(new ResourceAccessException("Read timed out"));
+
+        Health health = healthIndicator.health();
+
+        assertThat(health.getStatus()).isEqualTo(Status.DOWN);
+        assertThat(health.getDetails()).containsKey("url");
+        assertThat(health.getDetails().get("url")).isEqualTo(BASE_URL);
+    }
+}

--- a/allocations/access-ci-service/src/test/java/org/apache/custos/access/ci/service/metrics/AmieMetricsTest.java
+++ b/allocations/access-ci-service/src/test/java/org/apache/custos/access/ci/service/metrics/AmieMetricsTest.java
@@ -1,0 +1,129 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ */
+package org.apache.custos.access.ci.service.metrics;
+
+import io.micrometer.core.instrument.Counter;
+import io.micrometer.core.instrument.Timer;
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@Tag("unit")
+class AmieMetricsTest {
+
+    private SimpleMeterRegistry registry;
+    private AmieMetrics amieMetrics;
+
+    @BeforeEach
+    void setUp() {
+        registry = new SimpleMeterRegistry();
+        amieMetrics = new AmieMetrics(registry);
+    }
+
+    @Test
+    void recordPacketReceived_shouldIncrementCounterWithTypeTag() {
+        amieMetrics.recordPacketReceived("request_project_create");
+        amieMetrics.recordPacketReceived("request_project_create");
+        amieMetrics.recordPacketReceived("request_user_modify");
+
+        Counter createCounter = registry.find("amie_packets_received_total")
+                .tag("type", "request_project_create")
+                .counter();
+        Counter modifyCounter = registry.find("amie_packets_received_total")
+                .tag("type", "request_user_modify")
+                .counter();
+
+        assertThat(createCounter).isNotNull();
+        assertThat(createCounter.count()).isEqualTo(2.0);
+        assertThat(modifyCounter).isNotNull();
+        assertThat(modifyCounter.count()).isEqualTo(1.0);
+    }
+
+    @Test
+    void recordPacketProcessed_shouldIncrementCounterWithTypeAndOutcomeTags() {
+        amieMetrics.recordPacketProcessed("request_project_create", "success");
+        amieMetrics.recordPacketProcessed("request_project_create", "failure");
+        amieMetrics.recordPacketProcessed("request_project_create", "success");
+
+        Counter successCounter = registry.find("amie_packets_processed_total")
+                .tag("type", "request_project_create")
+                .tag("outcome", "success")
+                .counter();
+        Counter failureCounter = registry.find("amie_packets_processed_total")
+                .tag("type", "request_project_create")
+                .tag("outcome", "failure")
+                .counter();
+
+        assertThat(successCounter).isNotNull();
+        assertThat(successCounter.count()).isEqualTo(2.0);
+        assertThat(failureCounter).isNotNull();
+        assertThat(failureCounter.count()).isEqualTo(1.0);
+    }
+
+    @Test
+    void recordRetry_shouldIncrementRetryCounter() {
+        amieMetrics.recordRetry();
+        amieMetrics.recordRetry();
+        amieMetrics.recordRetry();
+
+        Counter retryCounter = registry.find("amie_events_retry_total").counter();
+
+        assertThat(retryCounter).isNotNull();
+        assertThat(retryCounter.count()).isEqualTo(3.0);
+    }
+
+    @Test
+    void startAndStopProcessingTimer_shouldRecordDurationWithHandlerTag() throws InterruptedException {
+        Timer.Sample sample = amieMetrics.startProcessingTimer();
+        Thread.sleep(5);
+        amieMetrics.stopProcessingTimer(sample, "RequestProjectCreateHandler");
+
+        Timer timer = registry.find("amie_packet_processing_duration_seconds")
+                .tag("handler", "RequestProjectCreateHandler")
+                .timer();
+
+        assertThat(timer).isNotNull();
+        assertThat(timer.count()).isEqualTo(1);
+        assertThat(timer.totalTime(java.util.concurrent.TimeUnit.MILLISECONDS)).isGreaterThan(0);
+    }
+
+    @Test
+    void recordPollerFetch_shouldIncrementByCount() {
+        amieMetrics.recordPollerFetch(5);
+        amieMetrics.recordPollerFetch(3);
+
+        Counter fetchCounter = registry.find("amie_poller_packets_fetched").counter();
+
+        assertThat(fetchCounter).isNotNull();
+        assertThat(fetchCounter.count()).isEqualTo(8.0);
+    }
+
+    @Test
+    void recordPollerFetch_withZeroCount_shouldNotChangeCounter() {
+        amieMetrics.recordPollerFetch(0);
+
+        Counter fetchCounter = registry.find("amie_poller_packets_fetched").counter();
+
+        assertThat(fetchCounter).isNotNull();
+        assertThat(fetchCounter.count()).isEqualTo(0.0);
+    }
+}

--- a/allocations/access-ci-service/src/test/java/org/apache/custos/access/ci/service/service/AuditServiceTest.java
+++ b/allocations/access-ci-service/src/test/java/org/apache/custos/access/ci/service/service/AuditServiceTest.java
@@ -1,0 +1,152 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ */
+package org.apache.custos.access.ci.service.service;
+
+import org.apache.custos.access.ci.service.model.amie.AuditAction;
+import org.apache.custos.access.ci.service.model.amie.AuditLogEntity;
+import org.apache.custos.access.ci.service.model.amie.PacketEntity;
+import org.apache.custos.access.ci.service.model.amie.ProcessingEventEntity;
+import org.apache.custos.access.ci.service.repo.amie.AuditLogRepository;
+import org.apache.custos.access.ci.service.repo.amie.PacketRepository;
+import org.apache.custos.access.ci.service.repo.amie.ProcessingEventRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+@Tag("unit")
+class AuditServiceTest {
+
+    @Mock
+    private AuditLogRepository auditLogRepository;
+
+    @Mock
+    private PacketRepository packetRepository;
+
+    @Mock
+    private ProcessingEventRepository processingEventRepository;
+
+    private AuditService auditService;
+
+    @BeforeEach
+    void setUp() {
+        auditService = new AuditService(auditLogRepository, packetRepository, processingEventRepository);
+    }
+
+    @Test
+    void log_withEventId_shouldCreateAuditEntryWithAllFields() {
+        String packetId = "packet-001";
+        String eventId = "event-abc";
+        PacketEntity packetProxy = new PacketEntity();
+        ProcessingEventEntity eventProxy = new ProcessingEventEntity();
+
+        when(packetRepository.getReferenceById(packetId)).thenReturn(packetProxy);
+        when(processingEventRepository.getReferenceById(eventId)).thenReturn(eventProxy);
+        when(auditLogRepository.save(any(AuditLogEntity.class))).thenAnswer(inv -> inv.getArgument(0));
+
+        auditService.log(packetId, eventId, AuditAction.CREATE_PERSON, "Person", "person-123", "Created person from packet");
+
+        ArgumentCaptor<AuditLogEntity> captor = ArgumentCaptor.forClass(AuditLogEntity.class);
+        verify(auditLogRepository).save(captor.capture());
+
+        AuditLogEntity saved = captor.getValue();
+        assertThat(saved.getPacket()).isSameAs(packetProxy);
+        assertThat(saved.getEvent()).isSameAs(eventProxy);
+        assertThat(saved.getAction()).isEqualTo(AuditAction.CREATE_PERSON);
+        assertThat(saved.getEntityType()).isEqualTo("Person");
+        assertThat(saved.getEntityId()).isEqualTo("person-123");
+        assertThat(saved.getSummary()).isEqualTo("Created person from packet");
+        assertThat(saved.getCreatedAt()).isNotNull();
+    }
+
+    @Test
+    void log_withNullEventId_shouldCreateAuditEntryWithNullEvent() {
+        String packetId = "packet-002";
+        PacketEntity packetProxy = new PacketEntity();
+
+        when(packetRepository.getReferenceById(packetId)).thenReturn(packetProxy);
+        when(auditLogRepository.save(any(AuditLogEntity.class))).thenAnswer(inv -> inv.getArgument(0));
+
+        auditService.log(packetId, null, AuditAction.REPLY_SENT, "Packet", null, "Reply dispatched");
+
+        ArgumentCaptor<AuditLogEntity> captor = ArgumentCaptor.forClass(AuditLogEntity.class);
+        verify(auditLogRepository).save(captor.capture());
+
+        AuditLogEntity saved = captor.getValue();
+        assertThat(saved.getPacket()).isSameAs(packetProxy);
+        assertThat(saved.getEvent()).isNull();
+        assertThat(saved.getAction()).isEqualTo(AuditAction.REPLY_SENT);
+        assertThat(saved.getEntityType()).isEqualTo("Packet");
+        assertThat(saved.getEntityId()).isNull();
+        assertThat(saved.getSummary()).isEqualTo("Reply dispatched");
+    }
+
+    @Test
+    void log_withNullSummaryAndEntityId_shouldSaveEntityWithNulls() {
+        String packetId = "packet-003";
+        PacketEntity packetProxy = new PacketEntity();
+
+        when(packetRepository.getReferenceById(packetId)).thenReturn(packetProxy);
+        when(auditLogRepository.save(any(AuditLogEntity.class))).thenAnswer(inv -> inv.getArgument(0));
+
+        auditService.log(packetId, null, AuditAction.TRANSACTION_COMPLETE, "Transaction", null, null);
+
+        ArgumentCaptor<AuditLogEntity> captor = ArgumentCaptor.forClass(AuditLogEntity.class);
+        verify(auditLogRepository).save(captor.capture());
+
+        AuditLogEntity saved = captor.getValue();
+        assertThat(saved.getAction()).isEqualTo(AuditAction.TRANSACTION_COMPLETE);
+        assertThat(saved.getEntityId()).isNull();
+        assertThat(saved.getSummary()).isNull();
+    }
+
+    @Test
+    void log_usesGetReferenceByIdForPacketProxy() {
+        String packetId = "packet-004";
+        PacketEntity proxy = new PacketEntity();
+        when(packetRepository.getReferenceById(packetId)).thenReturn(proxy);
+        when(auditLogRepository.save(any(AuditLogEntity.class))).thenAnswer(inv -> inv.getArgument(0));
+
+        auditService.log(packetId, null, AuditAction.CREATE_PROJECT, "Project", "proj-1", null);
+
+        verify(packetRepository).getReferenceById(packetId);
+    }
+
+    @Test
+    void log_usesGetReferenceByIdForEventProxy() {
+        String packetId = "packet-005";
+        String eventId = "event-xyz";
+        when(packetRepository.getReferenceById(packetId)).thenReturn(new PacketEntity());
+        when(processingEventRepository.getReferenceById(eventId)).thenReturn(new ProcessingEventEntity());
+        when(auditLogRepository.save(any(AuditLogEntity.class))).thenAnswer(inv -> inv.getArgument(0));
+
+        auditService.log(packetId, eventId, AuditAction.CREATE_MEMBERSHIP, "Membership", "m-1", null);
+
+        verify(processingEventRepository).getReferenceById(eventId);
+    }
+}

--- a/allocations/access-ci-service/src/test/java/org/apache/custos/access/ci/service/service/PersonServiceTest.java
+++ b/allocations/access-ci-service/src/test/java/org/apache/custos/access/ci/service/service/PersonServiceTest.java
@@ -120,6 +120,10 @@ class PersonServiceTest {
                 .hasMessageContaining("Packet body must contain a 'UserGlobalID'");
     }
 
+    // -------------------------------------------------------------------------
+    // replaceFromModifyPacket
+    // -------------------------------------------------------------------------
+
     @Test
     void replaceFromModifyPacket_shouldUpdatePersonFields() {
         JsonNode body = createModifyPacketBody();
@@ -138,6 +142,95 @@ class PersonServiceTest {
     }
 
     @Test
+    void replaceFromModifyPacket_shouldUseCorrectAmieFieldNames() {
+        // Verify that the correct AMIE field names are used (UserFirstName not FirstName, etc.)
+        ObjectNode body = objectMapper.createObjectNode()
+                .put("PersonID", "person-123")
+                .put("UserFirstName", "Updated")
+                .put("UserLastName", "Name")
+                .put("UserEmail", "updated@example.com")
+                .put("UserOrganization", "Updated Org")
+                .put("UserOrgCode", "UPD")
+                .put("NsfStatusCode", "INACTIVE");
+
+        PersonEntity existingPerson = createPersonEntity();
+        when(personRepository.findById("person-123")).thenReturn(Optional.of(existingPerson));
+
+        personService.replaceFromModifyPacket(body);
+
+        assertThat(existingPerson.getFirstName()).isEqualTo("Updated");
+        assertThat(existingPerson.getLastName()).isEqualTo("Name");
+        assertThat(existingPerson.getEmail()).isEqualTo("updated@example.com");
+        assertThat(existingPerson.getOrganization()).isEqualTo("Updated Org");
+        assertThat(existingPerson.getOrgCode()).isEqualTo("UPD");
+        assertThat(existingPerson.getNsfStatusCode()).isEqualTo("INACTIVE");
+    }
+
+    @Test
+    void replaceFromModifyPacket_shouldNotWipeFieldsAbsentFromPacket() {
+        // Packet only contains PersonID and UserFirstName — other fields must remain unchanged
+        ObjectNode body = objectMapper.createObjectNode()
+                .put("PersonID", "person-123")
+                .put("UserFirstName", "OnlyFirstUpdated");
+
+        PersonEntity existingPerson = createPersonEntity();
+        // Pre-existing values that must survive
+        existingPerson.setLastName("OriginalLast");
+        existingPerson.setEmail("original@example.com");
+        existingPerson.setOrganization("Original Org");
+        existingPerson.setOrgCode("ORIG");
+        existingPerson.setNsfStatusCode("ACTIVE");
+
+        when(personRepository.findById("person-123")).thenReturn(Optional.of(existingPerson));
+
+        personService.replaceFromModifyPacket(body);
+
+        assertThat(existingPerson.getFirstName()).isEqualTo("OnlyFirstUpdated");
+        assertThat(existingPerson.getLastName()).isEqualTo("OriginalLast");
+        assertThat(existingPerson.getEmail()).isEqualTo("original@example.com");
+        assertThat(existingPerson.getOrganization()).isEqualTo("Original Org");
+        assertThat(existingPerson.getOrgCode()).isEqualTo("ORIG");
+        assertThat(existingPerson.getNsfStatusCode()).isEqualTo("ACTIVE");
+    }
+
+    @Test
+    void replaceFromModifyPacket_shouldNotWipeOrganizationWhenAbsent() {
+        // Regression test: old code unconditionally wiped organization/orgCode to null when field absent
+        ObjectNode body = objectMapper.createObjectNode()
+                .put("PersonID", "person-123")
+                .put("UserFirstName", "Jane");
+        // No UserOrganization, UserOrgCode in packet
+
+        PersonEntity existingPerson = createPersonEntity();
+        existingPerson.setOrganization("Keep This Org");
+        existingPerson.setOrgCode("KEEP");
+
+        when(personRepository.findById("person-123")).thenReturn(Optional.of(existingPerson));
+
+        personService.replaceFromModifyPacket(body);
+
+        assertThat(existingPerson.getOrganization()).isEqualTo("Keep This Org");
+        assertThat(existingPerson.getOrgCode()).isEqualTo("KEEP");
+    }
+
+    @Test
+    void replaceFromModifyPacket_shouldNotClearDnsWhenUserDnListAbsent() {
+        // When UserDnList is not present in the packet, existing DNs must not be touched
+        ObjectNode body = objectMapper.createObjectNode()
+                .put("PersonID", "person-123")
+                .put("UserFirstName", "Jane");
+        // No UserDnList field
+
+        PersonEntity existingPerson = createPersonEntity();
+        when(personRepository.findById("person-123")).thenReturn(Optional.of(existingPerson));
+
+        personService.replaceFromModifyPacket(body);
+
+        // deleteByPerson_Id should NOT have been called since UserDnList was absent
+        verify(personDnsRepository, never()).deleteByPerson_Id("person-123");
+    }
+
+    @Test
     void replaceFromModifyPacket_shouldUpdateDnList() {
         JsonNode body = createModifyPacketBodyWithDns();
         PersonEntity existingPerson = createPersonEntity();
@@ -152,8 +245,23 @@ class PersonServiceTest {
     }
 
     @Test
+    void replaceFromModifyPacket_shouldClearDnsWhenEmptyUserDnListPresent() {
+        // When UserDnList is present but empty, existing DNs should be cleared
+        ObjectNode body = objectMapper.createObjectNode()
+                .put("PersonID", "person-123");
+        body.set("UserDnList", objectMapper.createArrayNode()); // explicitly empty array
+
+        PersonEntity existingPerson = createPersonEntity();
+        when(personRepository.findById("person-123")).thenReturn(Optional.of(existingPerson));
+
+        personService.replaceFromModifyPacket(body);
+
+        verify(personDnsRepository).deleteByPerson_Id("person-123");
+    }
+
+    @Test
     void replaceFromModifyPacket_shouldThrowExceptionForMissingPersonId() {
-        ObjectNode body = objectMapper.createObjectNode().put("FirstName", "Jane");
+        ObjectNode body = objectMapper.createObjectNode().put("UserFirstName", "Jane");
 
         assertThatThrownBy(() -> personService.replaceFromModifyPacket(body))
                 .isInstanceOf(IllegalArgumentException.class)
@@ -170,6 +278,84 @@ class PersonServiceTest {
                 .hasMessageContaining("Unknown local PersonID: person-123");
     }
 
+    // -------------------------------------------------------------------------
+    // persistDnsForPerson tests
+    // -------------------------------------------------------------------------
+
+    @Test
+    void persistDnsForPerson_shouldPersistNewDns() {
+        PersonEntity existingPerson = createPersonEntity();
+        when(personRepository.findById("person-123")).thenReturn(Optional.of(existingPerson));
+        when(personDnsRepository.existsByPerson_IdAndDn("person-123", "/C=US/O=Test/CN=John Doe")).thenReturn(false);
+
+        JsonNode dnList = objectMapper.createArrayNode().add("/C=US/O=Test/CN=John Doe");
+        personService.persistDnsForPerson("person-123", dnList);
+
+        ArgumentCaptor<PersonDnsEntity> captor = ArgumentCaptor.forClass(PersonDnsEntity.class);
+        verify(personDnsRepository).save(captor.capture());
+        assertThat(captor.getValue().getDn()).isEqualTo("/C=US/O=Test/CN=John Doe");
+    }
+
+    @Test
+    void persistDnsForPerson_shouldBeIdempotentWhenDnAlreadyExists() {
+        PersonEntity existingPerson = createPersonEntity();
+        when(personRepository.findById("person-123")).thenReturn(Optional.of(existingPerson));
+        when(personDnsRepository.existsByPerson_IdAndDn("person-123", "/C=US/O=Test/CN=John Doe")).thenReturn(true);
+
+        JsonNode dnList = objectMapper.createArrayNode().add("/C=US/O=Test/CN=John Doe");
+        personService.persistDnsForPerson("person-123", dnList);
+
+        verify(personDnsRepository, never()).save(any(PersonDnsEntity.class));
+    }
+
+    @Test
+    void persistDnsForPerson_shouldPersistOnlyNewDnsWhenSomeDnsAlreadyExist() {
+        PersonEntity existingPerson = createPersonEntity();
+        when(personRepository.findById("person-123")).thenReturn(Optional.of(existingPerson));
+        when(personDnsRepository.existsByPerson_IdAndDn("person-123", "/C=US/O=Existing/CN=John")).thenReturn(true);
+        when(personDnsRepository.existsByPerson_IdAndDn("person-123", "/C=US/O=New/CN=John")).thenReturn(false);
+
+        JsonNode dnList = objectMapper.createArrayNode()
+                .add("/C=US/O=Existing/CN=John")
+                .add("/C=US/O=New/CN=John");
+        personService.persistDnsForPerson("person-123", dnList);
+
+        ArgumentCaptor<PersonDnsEntity> captor = ArgumentCaptor.forClass(PersonDnsEntity.class);
+        verify(personDnsRepository, times(1)).save(captor.capture());
+        assertThat(captor.getValue().getDn()).isEqualTo("/C=US/O=New/CN=John");
+    }
+
+    @Test
+    void persistDnsForPerson_shouldDoNothingForNullDnList() {
+        personService.persistDnsForPerson("person-123", null);
+
+        verify(personRepository, never()).findById(any());
+        verify(personDnsRepository, never()).save(any());
+    }
+
+    @Test
+    void persistDnsForPerson_shouldDoNothingForEmptyDnList() {
+        JsonNode emptyDnList = objectMapper.createArrayNode();
+        personService.persistDnsForPerson("person-123", emptyDnList);
+
+        verify(personRepository, never()).findById(any());
+        verify(personDnsRepository, never()).save(any());
+    }
+
+    @Test
+    void persistDnsForPerson_shouldThrowForUnknownPersonId() {
+        when(personRepository.findById("unknown-id")).thenReturn(Optional.empty());
+        JsonNode dnList = objectMapper.createArrayNode().add("/C=US/O=Test/CN=John");
+
+        assertThatThrownBy(() -> personService.persistDnsForPerson("unknown-id", dnList))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("Unknown local PersonID: unknown-id");
+    }
+
+    // -------------------------------------------------------------------------
+    // deleteFromModifyPacket tests
+    // -------------------------------------------------------------------------
+
     @Test
     void deleteFromModifyPacket_shouldDeletePerson() {
         JsonNode body = createModifyPacketBody();
@@ -179,12 +365,16 @@ class PersonServiceTest {
 
     @Test
     void deleteFromModifyPacket_shouldThrowExceptionForMissingPersonId() {
-        ObjectNode body = objectMapper.createObjectNode().put("FirstName", "Jane");
+        ObjectNode body = objectMapper.createObjectNode().put("UserFirstName", "Jane");
 
         assertThatThrownBy(() -> personService.deleteFromModifyPacket(body))
                 .isInstanceOf(IllegalArgumentException.class)
                 .hasMessageContaining("Missing required 'PersonID'");
     }
+
+    // -------------------------------------------------------------------------
+    // mergePersons tests
+    // -------------------------------------------------------------------------
 
     @Test
     void mergePersons_shouldMergeSuccessfully() {
@@ -228,6 +418,10 @@ class PersonServiceTest {
                 .hasMessageContaining("Could not find retiring person with local ID: retiring-person-123");
     }
 
+    // -------------------------------------------------------------------------
+    // Test data helpers
+    // -------------------------------------------------------------------------
+
     private JsonNode createValidPacketBody() {
         return objectMapper.createObjectNode()
                 .put("UserGlobalID", "USER-GLOBAL-123")
@@ -249,20 +443,20 @@ class PersonServiceTest {
     private JsonNode createModifyPacketBody() {
         return objectMapper.createObjectNode()
                 .put("PersonID", "person-123")
-                .put("FirstName", "Jane")
-                .put("LastName", "Smith")
-                .put("Email", "jane.smith@example.com")
-                .put("Organization", "New Org")
-                .put("OrgCode", "NEW")
+                .put("UserFirstName", "Jane")
+                .put("UserLastName", "Smith")
+                .put("UserEmail", "jane.smith@example.com")
+                .put("UserOrganization", "New Org")
+                .put("UserOrgCode", "NEW")
                 .put("NsfStatusCode", "INACTIVE");
     }
 
     private JsonNode createModifyPacketBodyWithDns() {
         return objectMapper.createObjectNode()
                 .put("PersonID", "person-123")
-                .put("FirstName", "Jane")
-                .put("LastName", "Smith")
-                .set("DnList", objectMapper.createArrayNode().add("CN=Jane Smith,OU=Users,DC=example,DC=com"));
+                .put("UserFirstName", "Jane")
+                .put("UserLastName", "Smith")
+                .set("UserDnList", objectMapper.createArrayNode().add("CN=Jane Smith,OU=Users,DC=example,DC=com"));
     }
 
     private PersonEntity createPersonEntity() {

--- a/allocations/access-ci-service/src/test/java/org/apache/custos/access/ci/service/service/ProjectMembershipServiceTest.java
+++ b/allocations/access-ci-service/src/test/java/org/apache/custos/access/ci/service/service/ProjectMembershipServiceTest.java
@@ -1,3 +1,21 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
 package org.apache.custos.access.ci.service.service;
 
 import org.apache.custos.access.ci.service.model.ClusterAccountEntity;
@@ -42,16 +60,59 @@ class ProjectMembershipServiceTest {
     }
 
     @Test
-    void createMembership_shouldReturnExistingMembership() {
+    void createMembership_shouldReturnExistingActiveMembership() {
         ProjectMembershipEntity existingMembership = createMembershipEntity();
+        existingMembership.setActive(true);
         when(membershipRepository.findByProjectIdAndClusterAccountId("PROJECT-123", "ACCOUNT-456"))
                 .thenReturn(Optional.of(existingMembership));
 
         ProjectMembershipEntity result = membershipService.createMembership("PROJECT-123", "ACCOUNT-456", "PI");
 
         assertThat(result).isEqualTo(existingMembership);
+        assertThat(result.isActive()).isTrue();
         verify(membershipRepository).findByProjectIdAndClusterAccountId("PROJECT-123", "ACCOUNT-456");
         verify(membershipRepository, never()).save(any(ProjectMembershipEntity.class));
+    }
+
+    @Test
+    void createMembership_shouldReactivateInactiveMembership() {
+        ProjectMembershipEntity inactiveMembership = createMembershipEntity();
+        inactiveMembership.setActive(false);
+        when(membershipRepository.findByProjectIdAndClusterAccountId("PROJECT-123", "ACCOUNT-456"))
+                .thenReturn(Optional.of(inactiveMembership));
+        when(membershipRepository.save(any(ProjectMembershipEntity.class)))
+                .thenAnswer(invocation -> invocation.<ProjectMembershipEntity>getArgument(0));
+
+        ProjectMembershipEntity result = membershipService.createMembership("PROJECT-123", "ACCOUNT-456", "USER");
+
+        assertThat(result).isSameAs(inactiveMembership);
+        assertThat(result.isActive()).isTrue();
+        assertThat(result.getRole()).isEqualTo("USER");
+        verify(membershipRepository).save(inactiveMembership);
+    }
+
+    @Test
+    void createMembership_calledTwiceForSamePair_shouldNotCreateDuplicate() {
+        ProjectEntity project = createProjectEntity();
+        ClusterAccountEntity clusterAccount = createClusterAccountEntity();
+
+        // First call: no membership exists.
+        when(membershipRepository.findByProjectIdAndClusterAccountId("PROJECT-123", "ACCOUNT-456"))
+                .thenReturn(Optional.empty());
+        when(projectRepository.findById("PROJECT-123")).thenReturn(Optional.of(project));
+        when(clusterAccountRepository.findById("ACCOUNT-456")).thenReturn(Optional.of(clusterAccount));
+        when(membershipRepository.save(any(ProjectMembershipEntity.class)))
+                .thenAnswer(invocation -> invocation.<ProjectMembershipEntity>getArgument(0));
+
+        ProjectMembershipEntity firstResult = membershipService.createMembership("PROJECT-123", "ACCOUNT-456", "PI");
+        assertThat(firstResult.isActive()).isTrue();
+
+        // Second call: membership now exists and is active.
+        when(membershipRepository.findByProjectIdAndClusterAccountId("PROJECT-123", "ACCOUNT-456"))
+                .thenReturn(Optional.of(firstResult));
+
+        ProjectMembershipEntity secondResult = membershipService.createMembership("PROJECT-123", "ACCOUNT-456", "PI");
+        assertThat(secondResult).isSameAs(firstResult);
     }
 
     @Test
@@ -98,8 +159,12 @@ class ProjectMembershipServiceTest {
                 .hasMessageContaining("Cluster account not found: ACCOUNT-456");
     }
 
+    // -------------------------------------------------------------------------
+    // inactivateMembershipsByPersonAndProject tests
+    // -------------------------------------------------------------------------
+
     @Test
-    void inactivateMembershipsByPersonAndProject_shouldInactivateMemberships() {
+    void inactivateMembershipsByPersonAndProject_shouldInactivateMembershipsAndReturnCount() {
         ProjectMembershipEntity membership1 = createMembershipEntity();
         ProjectMembershipEntity membership2 = createMembershipEntity();
         membership2.setId("membership-2");
@@ -107,19 +172,27 @@ class ProjectMembershipServiceTest {
         List<ProjectMembershipEntity> memberships = List.of(membership1, membership2);
         when(membershipRepository.findByProjectIdAndClusterAccount_Person_Id("PROJECT-123", "PERSON-456")).thenReturn(memberships);
 
-        membershipService.inactivateMembershipsByPersonAndProject("PROJECT-123", "PERSON-456");
+        int count = membershipService.inactivateMembershipsByPersonAndProject("PROJECT-123", "PERSON-456");
 
+        assertThat(count).isEqualTo(2);
         assertThat(membership1.isActive()).isFalse();
         assertThat(membership2.isActive()).isFalse();
         verify(membershipRepository).saveAll(memberships);
     }
 
     @Test
-    void inactivateMembershipsByPersonAndProject_shouldHandleNoMemberships() {
+    void inactivateMembershipsByPersonAndProject_shouldReturnZeroWhenNoMembershipsFound() {
         when(membershipRepository.findByProjectIdAndClusterAccount_Person_Id("PROJECT-123", "PERSON-456")).thenReturn(List.of());
-        membershipService.inactivateMembershipsByPersonAndProject("PROJECT-123", "PERSON-456");
+
+        int count = membershipService.inactivateMembershipsByPersonAndProject("PROJECT-123", "PERSON-456");
+
+        assertThat(count).isZero();
         verify(membershipRepository, never()).saveAll(any());
     }
+
+    // -------------------------------------------------------------------------
+    // inactivateAllMembershipsForProject tests
+    // -------------------------------------------------------------------------
 
     @Test
     void inactivateAllMembershipsForProject_shouldInactivateAllMemberships() {
@@ -143,6 +216,10 @@ class ProjectMembershipServiceTest {
         membershipService.inactivateAllMembershipsForProject("PROJECT-123");
         verify(membershipRepository, never()).saveAll(any());
     }
+
+    // -------------------------------------------------------------------------
+    // reactivatePiMembership tests
+    // -------------------------------------------------------------------------
 
     @Test
     void reactivatePiMembership_shouldReactivatePiMemberships() {
@@ -170,6 +247,39 @@ class ProjectMembershipServiceTest {
         when(membershipRepository.findByProjectIdAndRole("PROJECT-123", "PI")).thenReturn(List.of());
         membershipService.reactivatePiMembership("PROJECT-123");
         verify(membershipRepository).saveAll(List.of());
+    }
+
+    // -------------------------------------------------------------------------
+    // reactivateMembershipsByPersonAndProject tests
+    // -------------------------------------------------------------------------
+
+    @Test
+    void reactivateMembershipsByPersonAndProject_shouldReactivateMembershipsAndReturnCount() {
+        ProjectMembershipEntity membership1 = createMembershipEntity();
+        membership1.setActive(false);
+        ProjectMembershipEntity membership2 = createMembershipEntity();
+        membership2.setId("membership-2");
+        membership2.setActive(false);
+
+        List<ProjectMembershipEntity> memberships = List.of(membership1, membership2);
+        when(membershipRepository.findByProjectIdAndClusterAccount_Person_Id("PROJECT-123", "PERSON-456")).thenReturn(memberships);
+
+        int count = membershipService.reactivateMembershipsByPersonAndProject("PROJECT-123", "PERSON-456");
+
+        assertThat(count).isEqualTo(2);
+        assertThat(membership1.isActive()).isTrue();
+        assertThat(membership2.isActive()).isTrue();
+        verify(membershipRepository).saveAll(memberships);
+    }
+
+    @Test
+    void reactivateMembershipsByPersonAndProject_shouldReturnZeroWhenNoMembershipsFound() {
+        when(membershipRepository.findByProjectIdAndClusterAccount_Person_Id("PROJECT-123", "PERSON-456")).thenReturn(List.of());
+
+        int count = membershipService.reactivateMembershipsByPersonAndProject("PROJECT-123", "PERSON-456");
+
+        assertThat(count).isZero();
+        verify(membershipRepository, never()).saveAll(any());
     }
 
     private ProjectEntity createProjectEntity() {

--- a/allocations/access-ci-service/src/test/java/org/apache/custos/access/ci/service/service/UserAccountServiceTest.java
+++ b/allocations/access-ci-service/src/test/java/org/apache/custos/access/ci/service/service/UserAccountServiceTest.java
@@ -1,3 +1,21 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ */
 package org.apache.custos.access.ci.service.service;
 
 import org.apache.custos.access.ci.service.model.ClusterAccountEntity;
@@ -10,11 +28,13 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
+import java.util.List;
 import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -33,8 +53,48 @@ class UserAccountServiceTest {
     }
 
     @Test
+    void provisionClusterAccount_shouldReturnExistingAccountWhenPersonAlreadyHasOne() {
+        PersonEntity person = createPersonEntity();
+        ClusterAccountEntity existingAccount = createClusterAccountEntity(person, "jdoe");
+        when(clusterAccountRepository.findByPerson(person)).thenReturn(List.of(existingAccount));
+
+        ClusterAccountEntity result = userAccountService.provisionClusterAccount(person);
+
+        assertThat(result).isSameAs(existingAccount);
+        assertThat(result.getUsername()).isEqualTo("jdoe");
+        verify(clusterAccountRepository, never()).save(any(ClusterAccountEntity.class));
+    }
+
+    @Test
+    void provisionClusterAccount_calledTwiceForSamePerson_shouldReturnSameAccountBothTimes() {
+        PersonEntity person = createPersonEntity();
+        ClusterAccountEntity existingAccount = createClusterAccountEntity(person, "jdoe");
+
+        // First call: no account exists yet, create one.
+        when(clusterAccountRepository.findByPerson(person)).thenReturn(List.of());
+        when(clusterAccountRepository.findByUsername("jdoe")).thenReturn(Optional.empty());
+        when(clusterAccountRepository.save(any(ClusterAccountEntity.class)))
+                .thenAnswer(invocation -> invocation.<ClusterAccountEntity>getArgument(0));
+
+        ClusterAccountEntity firstResult = userAccountService.provisionClusterAccount(person);
+        assertThat(firstResult.getUsername()).isEqualTo("jdoe");
+
+        // Second call: account now exists.
+        when(clusterAccountRepository.findByPerson(person)).thenReturn(List.of(existingAccount));
+
+        ClusterAccountEntity secondResult = userAccountService.provisionClusterAccount(person);
+        assertThat(secondResult).isSameAs(existingAccount);
+        assertThat(secondResult.getUsername()).isEqualTo("jdoe");
+    }
+
+    // -------------------------------------------------------------------------
+    // New account creation tests
+    // -------------------------------------------------------------------------
+
+    @Test
     void provisionClusterAccount_shouldCreateUniqueUsername() {
         PersonEntity person = createPersonEntity();
+        when(clusterAccountRepository.findByPerson(person)).thenReturn(List.of());
         when(clusterAccountRepository.findByUsername("jdoe")).thenReturn(Optional.empty());
         when(clusterAccountRepository.save(any(ClusterAccountEntity.class)))
                 .thenAnswer(invocation -> invocation.<ClusterAccountEntity>getArgument(0));
@@ -50,6 +110,7 @@ class UserAccountServiceTest {
     @Test
     void provisionClusterAccount_shouldGenerateUniqueUsernameWhenBaseIsTaken() {
         PersonEntity person = createPersonEntity();
+        when(clusterAccountRepository.findByPerson(person)).thenReturn(List.of());
         when(clusterAccountRepository.findByUsername("jdoe")).thenReturn(Optional.of(new ClusterAccountEntity()));
         when(clusterAccountRepository.findByUsername("jdoe1")).thenReturn(Optional.empty());
         when(clusterAccountRepository.save(any(ClusterAccountEntity.class)))
@@ -66,6 +127,7 @@ class UserAccountServiceTest {
     @Test
     void provisionClusterAccount_shouldHandleMultipleSuffixes() {
         PersonEntity person = createPersonEntity();
+        when(clusterAccountRepository.findByPerson(person)).thenReturn(List.of());
         when(clusterAccountRepository.findByUsername("jdoe")).thenReturn(Optional.of(new ClusterAccountEntity()));
         when(clusterAccountRepository.findByUsername("jdoe1")).thenReturn(Optional.of(new ClusterAccountEntity()));
         when(clusterAccountRepository.findByUsername("jdoe2")).thenReturn(Optional.empty());
@@ -85,6 +147,7 @@ class UserAccountServiceTest {
         PersonEntity person = createPersonEntity();
         person.setFirstName("John Michael");
         person.setLastName("Doe Smith");
+        when(clusterAccountRepository.findByPerson(person)).thenReturn(List.of());
         when(clusterAccountRepository.findByUsername("jdoe-smith")).thenReturn(Optional.empty());
         when(clusterAccountRepository.save(any(ClusterAccountEntity.class)))
                 .thenAnswer(invocation -> invocation.<ClusterAccountEntity>getArgument(0));
@@ -102,9 +165,14 @@ class UserAccountServiceTest {
         PersonEntity person = createPersonEntity();
         person.setFirstName("");
         person.setLastName("");
+        when(clusterAccountRepository.findByPerson(person)).thenReturn(List.of());
 
         assertThatThrownBy(() -> userAccountService.provisionClusterAccount(person)).isInstanceOf(StringIndexOutOfBoundsException.class);
     }
+
+    // -------------------------------------------------------------------------
+    // Helper factories
+    // -------------------------------------------------------------------------
 
     private PersonEntity createPersonEntity() {
         PersonEntity entity = new PersonEntity();
@@ -113,6 +181,14 @@ class UserAccountServiceTest {
         entity.setFirstName("John");
         entity.setLastName("Doe");
         entity.setEmail("john.doe@example.com");
+        return entity;
+    }
+
+    private ClusterAccountEntity createClusterAccountEntity(PersonEntity person, String username) {
+        ClusterAccountEntity entity = new ClusterAccountEntity();
+        entity.setId("account-456");
+        entity.setPerson(person);
+        entity.setUsername(username);
         return entity;
     }
 }

--- a/allocations/access-ci-service/src/test/java/org/apache/custos/access/ci/service/worker/amie/ProcessingEventWorkerTest.java
+++ b/allocations/access-ci-service/src/test/java/org/apache/custos/access/ci/service/worker/amie/ProcessingEventWorkerTest.java
@@ -1,0 +1,299 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ */
+package org.apache.custos.access.ci.service.worker.amie;
+
+import org.apache.custos.access.ci.service.handler.amie.PacketRouter;
+import org.apache.custos.access.ci.service.model.amie.PacketEntity;
+import org.apache.custos.access.ci.service.model.amie.PacketStatus;
+import org.apache.custos.access.ci.service.model.amie.ProcessingErrorEntity;
+import org.apache.custos.access.ci.service.model.amie.ProcessingEventEntity;
+import org.apache.custos.access.ci.service.model.amie.ProcessingEventType;
+import org.apache.custos.access.ci.service.model.amie.ProcessingStatus;
+import org.apache.custos.access.ci.service.repo.amie.PacketRepository;
+import org.apache.custos.access.ci.service.repo.amie.ProcessingErrorRepository;
+import org.apache.custos.access.ci.service.repo.amie.ProcessingEventRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.time.Instant;
+import java.util.List;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyList;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+/**
+ * Unit tests for ProcessingEventWorker.
+ */
+@ExtendWith(MockitoExtension.class)
+@Tag("unit")
+class ProcessingEventWorkerTest {
+
+    @Mock
+    private ProcessingEventRepository eventRepo;
+
+    @Mock
+    private PacketRepository packetRepo;
+
+    @Mock
+    private ProcessingErrorRepository errorRepo;
+
+    @Mock
+    private PacketRouter router;
+
+    @Mock
+    private ProcessingEventWorker self;
+
+    private ProcessingEventWorker worker;
+
+    @BeforeEach
+    void setUp() {
+        worker = new ProcessingEventWorker(eventRepo, packetRepo, errorRepo, router, self);
+    }
+
+    // ------------------------------------------------------------------
+    // processPendingEvents — orchestration
+    // ------------------------------------------------------------------
+
+    @Test
+    void processPendingEvents_whenNoEvents_doesNothing() throws Exception {
+        when(eventRepo.findTop50EventsToProcess(anyList(), any(Instant.class))).thenReturn(List.of());
+
+        worker.processPendingEvents();
+
+        verify(self, never()).executeEventInTransaction(any());
+        verify(self, never()).recordFailureInNewTransaction(any(), any());
+    }
+
+    @Test
+    void processPendingEvents_callsExecuteForEachEvent() throws Exception {
+        ProcessingEventEntity event1 = buildEvent("id-1", ProcessingStatus.NEW, 0);
+        ProcessingEventEntity event2 = buildEvent("id-2", ProcessingStatus.RETRY_SCHEDULED, 1);
+        when(eventRepo.findTop50EventsToProcess(anyList(), any(Instant.class)))
+                .thenReturn(List.of(event1, event2));
+
+        worker.processPendingEvents();
+
+        verify(self).executeEventInTransaction(event1);
+        verify(self).executeEventInTransaction(event2);
+        verify(self, never()).recordFailureInNewTransaction(any(), any());
+    }
+
+    @Test
+    void processPendingEvents_whenExecuteThrows_callsRecoveryTransactionWithEventId() throws Exception {
+        ProcessingEventEntity event = buildEvent("id-thrown", ProcessingStatus.NEW, 0);
+        when(eventRepo.findTop50EventsToProcess(anyList(), any(Instant.class)))
+                .thenReturn(List.of(event));
+
+        RuntimeException cause = new RuntimeException("handler blew up");
+        doThrow(cause).when(self).executeEventInTransaction(event);
+
+        worker.processPendingEvents();
+
+        verify(self).recordFailureInNewTransaction("id-thrown", cause);
+    }
+
+    @Test
+    void processPendingEvents_whenBothExecuteAndRecoveryThrow_continuesProcessingRemainingEvents() throws Exception {
+        ProcessingEventEntity badEvent = buildEvent("bad-id", ProcessingStatus.NEW, 0);
+        ProcessingEventEntity goodEvent = buildEvent("good-id", ProcessingStatus.NEW, 0);
+        when(eventRepo.findTop50EventsToProcess(anyList(), any(Instant.class)))
+                .thenReturn(List.of(badEvent, goodEvent));
+
+        RuntimeException executeCause = new RuntimeException("execute failed");
+        doThrow(executeCause).when(self).executeEventInTransaction(badEvent);
+        doThrow(new RuntimeException("recovery also failed"))
+                .when(self).recordFailureInNewTransaction("bad-id", executeCause);
+
+        // Should not propagate — the worker logs and continues to goodEvent.
+        worker.processPendingEvents();
+
+        verify(self).executeEventInTransaction(goodEvent);
+    }
+
+    // ------------------------------------------------------------------
+    // recordFailureInNewTransaction — retryable failures
+    // ------------------------------------------------------------------
+
+    @Test
+    void recordFailureInNewTransaction_onFirstFailure_setsRetryScheduledWithBackoff() {
+        ProcessingEventEntity event = buildEvent("evt-1", ProcessingStatus.NEW, 0);
+        PacketEntity packet = event.getPacket();
+        when(eventRepo.findById("evt-1")).thenReturn(Optional.of(event));
+
+        RuntimeException cause = new IllegalArgumentException("Project not found");
+        Instant before = Instant.now();
+
+        worker.recordFailureInNewTransaction("evt-1", cause);
+
+        Instant after = Instant.now();
+
+        assertThat(event.getStatus()).isEqualTo(ProcessingStatus.RETRY_SCHEDULED);
+        assertThat(event.getAttempts()).isEqualTo(1); // incremented from 0
+        assertThat(event.getLastError()).isEqualTo("Project not found");
+        assertThat(event.getNextRetryAt()).isNotNull();
+        // Backoff for attempt 1 = 30 s; nextRetryAt must be in the near future
+        assertThat(event.getNextRetryAt()).isAfterOrEqualTo(before.plusSeconds(29));
+        assertThat(event.getNextRetryAt()).isBeforeOrEqualTo(after.plusSeconds(31));
+
+        verify(eventRepo).save(event);
+        verify(packetRepo, never()).save(any());
+
+        ArgumentCaptor<ProcessingErrorEntity> errorCaptor = ArgumentCaptor.forClass(ProcessingErrorEntity.class);
+        verify(errorRepo).save(errorCaptor.capture());
+        ProcessingErrorEntity error = errorCaptor.getValue();
+        assertThat(error.getSummary()).contains("IllegalArgumentException");
+        assertThat(error.getSummary()).contains("Project not found");
+        assertThat(error.getPacket()).isSameAs(packet);
+        assertThat(error.getEvent()).isSameAs(event);
+    }
+
+    @Test
+    void recordFailureInNewTransaction_onSecondFailure_setsRetryScheduledWithDoubledBackoff() {
+        // Simulate: the first attempt rolled back (REQUIRES_NEW), so the event is
+        // re-read with RETRY_SCHEDULED status and attempts=1 (the previous committed
+        // retry count). The recovery method unconditionally increments attempts to 2
+        // and applies a 60-second backoff (BASE * 2^1).
+        ProcessingEventEntity event = buildEvent("evt-2", ProcessingStatus.RETRY_SCHEDULED, 1);
+        when(eventRepo.findById("evt-2")).thenReturn(Optional.of(event));
+
+        Instant before = Instant.now();
+        worker.recordFailureInNewTransaction("evt-2", new RuntimeException("second failure"));
+        Instant after = Instant.now();
+
+        assertThat(event.getStatus()).isEqualTo(ProcessingStatus.RETRY_SCHEDULED);
+        // Attempts unconditionally incremented from 1 to 2
+        assertThat(event.getAttempts()).isEqualTo(2);
+        // Backoff for attempt 2 = 60 s
+        assertThat(event.getNextRetryAt()).isAfterOrEqualTo(before.plusSeconds(59));
+        assertThat(event.getNextRetryAt()).isBeforeOrEqualTo(after.plusSeconds(61));
+    }
+
+    // ------------------------------------------------------------------
+    // recordFailureInNewTransaction — permanent failure
+    // ------------------------------------------------------------------
+
+    @Test
+    void recordFailureInNewTransaction_afterMaxAttempts_marksPermanentlyFailed() {
+        // Simulate event on its last allowed retry (attempts already at MAX-1 in RETRY_SCHEDULED)
+        // When we increment, it reaches MAX_ATTEMPTS = 3
+        ProcessingEventEntity event = buildEvent("evt-perm", ProcessingStatus.RETRY_SCHEDULED, 2);
+        PacketEntity packet = event.getPacket();
+        when(eventRepo.findById("evt-perm")).thenReturn(Optional.of(event));
+
+        RuntimeException cause = new RuntimeException("final failure");
+        worker.recordFailureInNewTransaction("evt-perm", cause);
+
+        assertThat(event.getStatus()).isEqualTo(ProcessingStatus.PERMANENTLY_FAILED);
+        assertThat(event.getAttempts()).isEqualTo(3);
+        assertThat(event.getNextRetryAt()).isNull();
+
+        // Packet must also be marked FAILED
+        verify(packetRepo).save(packet);
+        assertThat(packet.getStatus()).isEqualTo(PacketStatus.FAILED);
+        assertThat(packet.getLastError()).isEqualTo("final failure");
+
+        verify(eventRepo).save(event);
+        verify(errorRepo).save(any(ProcessingErrorEntity.class));
+    }
+
+    @Test
+    void recordFailureInNewTransaction_whenEventNotFound_doesNotThrow() {
+        when(eventRepo.findById("missing")).thenReturn(Optional.empty());
+
+        // Should log and return without throwing or saving anything
+        worker.recordFailureInNewTransaction("missing", new RuntimeException("cause"));
+
+        verify(eventRepo, never()).save(any());
+        verify(errorRepo, never()).save(any());
+    }
+
+    // ------------------------------------------------------------------
+    // computeNextRetryAt — exponential backoff
+    // ------------------------------------------------------------------
+
+    @Test
+    void computeNextRetryAt_attempt1_returns30SecondDelay() {
+        Instant before = Instant.now();
+        Instant result = ProcessingEventWorker.computeNextRetryAt(1);
+        Instant after = Instant.now();
+
+        assertThat(result).isAfterOrEqualTo(before.plusSeconds(29));
+        assertThat(result).isBeforeOrEqualTo(after.plusSeconds(31));
+    }
+
+    @Test
+    void computeNextRetryAt_attempt2_returns60SecondDelay() {
+        Instant before = Instant.now();
+        Instant result = ProcessingEventWorker.computeNextRetryAt(2);
+        Instant after = Instant.now();
+
+        assertThat(result).isAfterOrEqualTo(before.plusSeconds(59));
+        assertThat(result).isBeforeOrEqualTo(after.plusSeconds(61));
+    }
+
+    @Test
+    void computeNextRetryAt_highAttemptNumber_capsAtMaxBackoff() {
+        // At attempt 100, delay would be astronomically large without capping.
+        // MAX_BACKOFF_SECONDS = 600
+        Instant before = Instant.now();
+        Instant result = ProcessingEventWorker.computeNextRetryAt(100);
+        Instant after = Instant.now();
+
+        // Must not exceed MAX_BACKOFF_SECONDS + small tolerance
+        assertThat(result).isBeforeOrEqualTo(after.plusSeconds(601));
+        // Must still be at least MAX_BACKOFF_SECONDS in the future
+        assertThat(result).isAfterOrEqualTo(before.plusSeconds(599));
+    }
+
+    private ProcessingEventEntity buildEvent(String id, ProcessingStatus status, int attempts) {
+        PacketEntity packet = new PacketEntity();
+        packet.setAmieId(42L);
+        packet.setType("request_account_create");
+        packet.setStatus(PacketStatus.NEW);
+        // Provide minimal valid JSON so objectMapper.readTree won't NPE if called directly
+        packet.setRawJson("{\"body\":{}}");
+
+        ProcessingEventEntity event = new ProcessingEventEntity();
+        // Directly set the id field via reflection to avoid UUID randomness issues in tests
+        try {
+            java.lang.reflect.Field idField = ProcessingEventEntity.class.getDeclaredField("id");
+            idField.setAccessible(true);
+            idField.set(event, id);
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+        event.setPacket(packet);
+        event.setType(ProcessingEventType.DECODE_PACKET);
+        event.setStatus(status);
+        event.setAttempts(attempts);
+        event.setPayload(new byte[0]);
+        return event;
+    }
+}

--- a/allocations/access-ci-service/src/test/java/org/apache/custos/access/ci/service/worker/amie/ProcessingEventWorkerTest.java
+++ b/allocations/access-ci-service/src/test/java/org/apache/custos/access/ci/service/worker/amie/ProcessingEventWorkerTest.java
@@ -19,6 +19,7 @@
 package org.apache.custos.access.ci.service.worker.amie;
 
 import org.apache.custos.access.ci.service.handler.amie.PacketRouter;
+import org.apache.custos.access.ci.service.metrics.AmieMetrics;
 import org.apache.custos.access.ci.service.model.amie.PacketEntity;
 import org.apache.custos.access.ci.service.model.amie.PacketStatus;
 import org.apache.custos.access.ci.service.model.amie.ProcessingErrorEntity;
@@ -43,7 +44,9 @@ import java.util.Optional;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyList;
+import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -68,13 +71,17 @@ class ProcessingEventWorkerTest {
     private PacketRouter router;
 
     @Mock
+    private AmieMetrics amieMetrics;
+
+    @Mock
     private ProcessingEventWorker self;
 
     private ProcessingEventWorker worker;
 
     @BeforeEach
     void setUp() {
-        worker = new ProcessingEventWorker(eventRepo, packetRepo, errorRepo, router, self);
+        lenient().when(amieMetrics.startProcessingTimer()).thenReturn(null);
+        worker = new ProcessingEventWorker(eventRepo, packetRepo, errorRepo, router, amieMetrics, self);
     }
 
     // ------------------------------------------------------------------
@@ -103,6 +110,8 @@ class ProcessingEventWorkerTest {
         verify(self).executeEventInTransaction(event1);
         verify(self).executeEventInTransaction(event2);
         verify(self, never()).recordFailureInNewTransaction(any(), any());
+        verify(amieMetrics, org.mockito.Mockito.times(2)).startProcessingTimer();
+        verify(amieMetrics, org.mockito.Mockito.times(2)).stopProcessingTimer(any(), anyString());
     }
 
     @Test
@@ -164,6 +173,8 @@ class ProcessingEventWorkerTest {
 
         verify(eventRepo).save(event);
         verify(packetRepo, never()).save(any());
+        verify(amieMetrics).recordRetry();
+        verify(amieMetrics).recordPacketProcessed("request_account_create", "retry_scheduled");
 
         ArgumentCaptor<ProcessingErrorEntity> errorCaptor = ArgumentCaptor.forClass(ProcessingErrorEntity.class);
         verify(errorRepo).save(errorCaptor.capture());
@@ -218,6 +229,9 @@ class ProcessingEventWorkerTest {
         verify(packetRepo).save(packet);
         assertThat(packet.getStatus()).isEqualTo(PacketStatus.FAILED);
         assertThat(packet.getLastError()).isEqualTo("final failure");
+
+        verify(amieMetrics).recordPacketProcessed("request_account_create", "permanently_failed");
+        verify(amieMetrics, never()).recordRetry();
 
         verify(eventRepo).save(event);
         verify(errorRepo).save(any(ProcessingErrorEntity.class));

--- a/compose/docker-compose.yml
+++ b/compose/docker-compose.yml
@@ -57,6 +57,31 @@ services:
     ports:
       - 18080:8080
 
+  prometheus:
+    image: prom/prometheus:latest
+    container_name: prometheus
+    restart: unless-stopped
+    ports:
+      - "9090:9090"
+    volumes:
+      - ./prometheus/prometheus.yml:/etc/prometheus/prometheus.yml
+    extra_hosts:
+      - "host.docker.internal:host-gateway"
+
+  grafana:
+    image: grafana/grafana:latest
+    container_name: grafana
+    restart: unless-stopped
+    ports:
+      - "3000:3000"
+    environment:
+      GF_SECURITY_ADMIN_USER: admin
+      GF_SECURITY_ADMIN_PASSWORD: admin
+      GF_DASHBOARDS_DEFAULT_HOME_DASHBOARD_PATH: /var/lib/grafana/dashboards/amie-service.json
+    volumes:
+      - ./grafana/provisioning:/etc/grafana/provisioning
+      - ./grafana/dashboards:/var/lib/grafana/dashboards
+
   vault:
     image: vault:1.11.0
     container_name: vault

--- a/compose/grafana/dashboards/amie-service.json
+++ b/compose/grafana/dashboards/amie-service.json
@@ -1,0 +1,152 @@
+{
+  "annotations": { "list": [] },
+  "editable": true,
+  "fiscalYearStartMonth": 0,
+  "graphTooltip": 1,
+  "links": [],
+  "panels": [
+    {
+      "type": "stat",
+      "title": "Total Packets Received",
+      "gridPos": { "h": 4, "w": 6, "x": 0, "y": 0 },
+      "targets": [{ "expr": "sum(amie_packets_received_total)", "legendFormat": "Total" }],
+      "fieldConfig": { "defaults": { "thresholds": { "steps": [{ "color": "blue", "value": null }] } } },
+      "options": { "colorMode": "background", "textMode": "value_and_name" },
+      "datasource": { "type": "prometheus", "uid": "PBFA97CFB590B2093" }
+    },
+    {
+      "type": "stat",
+      "title": "Packets Succeeded",
+      "gridPos": { "h": 4, "w": 6, "x": 6, "y": 0 },
+      "targets": [{ "expr": "sum(amie_packets_processed_total{outcome=\"succeeded\"})", "legendFormat": "Succeeded" }],
+      "fieldConfig": { "defaults": { "thresholds": { "steps": [{ "color": "green", "value": null }] } } },
+      "options": { "colorMode": "background", "textMode": "value_and_name" },
+      "datasource": { "type": "prometheus", "uid": "PBFA97CFB590B2093" }
+    },
+    {
+      "type": "stat",
+      "title": "Packets Failed",
+      "gridPos": { "h": 4, "w": 6, "x": 12, "y": 0 },
+      "targets": [{ "expr": "sum(amie_packets_processed_total{outcome=~\"permanently_failed|failed\"})", "legendFormat": "Failed" }],
+      "fieldConfig": { "defaults": { "thresholds": { "steps": [{ "color": "green", "value": null }, { "color": "red", "value": 1 }] } } },
+      "options": { "colorMode": "background", "textMode": "value_and_name" },
+      "datasource": { "type": "prometheus", "uid": "PBFA97CFB590B2093" }
+    },
+    {
+      "type": "stat",
+      "title": "Retries",
+      "gridPos": { "h": 4, "w": 6, "x": 18, "y": 0 },
+      "targets": [{ "expr": "sum(amie_events_retry_total) or vector(0)", "legendFormat": "Retries" }],
+      "fieldConfig": { "defaults": { "thresholds": { "steps": [{ "color": "green", "value": null }, { "color": "orange", "value": 1 }, { "color": "red", "value": 5 }] } } },
+      "options": { "colorMode": "background", "textMode": "value_and_name" },
+      "datasource": { "type": "prometheus", "uid": "PBFA97CFB590B2093" }
+    },
+    {
+      "type": "timeseries",
+      "title": "Packets Processed Over Time",
+      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 4 },
+      "targets": [
+        { "expr": "sum by (type) (rate(amie_packets_processed_total{outcome=\"succeeded\"}[5m]))", "legendFormat": "{{type}}" }
+      ],
+      "fieldConfig": { "defaults": { "custom": { "drawStyle": "line", "lineWidth": 2, "fillOpacity": 15, "pointSize": 5, "showPoints": "auto" } } },
+      "options": { "tooltip": { "mode": "multi" }, "legend": { "displayMode": "table", "placement": "bottom", "calcs": ["sum"] } },
+      "datasource": { "type": "prometheus", "uid": "PBFA97CFB590B2093" }
+    },
+    {
+      "type": "timeseries",
+      "title": "Failures & Retries Over Time",
+      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 4 },
+      "targets": [
+        { "expr": "sum(rate(amie_packets_processed_total{outcome=~\"permanently_failed|retry_scheduled\"}[5m]))", "legendFormat": "Failures" },
+        { "expr": "sum(rate(amie_events_retry_total[5m]))", "legendFormat": "Retries" }
+      ],
+      "fieldConfig": { "defaults": { "custom": { "drawStyle": "line", "lineWidth": 2, "fillOpacity": 15 }, "color": { "mode": "palette-classic" } } },
+      "options": { "tooltip": { "mode": "multi" }, "legend": { "displayMode": "table", "placement": "bottom", "calcs": ["sum"] } },
+      "datasource": { "type": "prometheus", "uid": "PBFA97CFB590B2093" }
+    },
+    {
+      "type": "piechart",
+      "title": "Packets by Type",
+      "gridPos": { "h": 8, "w": 8, "x": 0, "y": 12 },
+      "targets": [
+        { "expr": "sum by (type) (amie_packets_received_total)", "legendFormat": "{{type}}" }
+      ],
+      "options": { "legend": { "displayMode": "table", "placement": "right", "values": ["value", "percent"] }, "pieType": "donut" },
+      "datasource": { "type": "prometheus", "uid": "PBFA97CFB590B2093" }
+    },
+    {
+      "type": "piechart",
+      "title": "Processing Outcomes",
+      "gridPos": { "h": 8, "w": 8, "x": 8, "y": 12 },
+      "targets": [
+        { "expr": "sum by (outcome) (amie_packets_processed_total)", "legendFormat": "{{outcome}}" }
+      ],
+      "fieldConfig": { "overrides": [
+        { "matcher": { "id": "byName", "options": "succeeded" }, "properties": [{ "id": "color", "value": { "fixedColor": "green", "mode": "fixed" } }] },
+        { "matcher": { "id": "byName", "options": "permanently_failed" }, "properties": [{ "id": "color", "value": { "fixedColor": "red", "mode": "fixed" } }] },
+        { "matcher": { "id": "byName", "options": "retry_scheduled" }, "properties": [{ "id": "color", "value": { "fixedColor": "orange", "mode": "fixed" } }] }
+      ] },
+      "options": { "legend": { "displayMode": "table", "placement": "right", "values": ["value", "percent"] }, "pieType": "donut" },
+      "datasource": { "type": "prometheus", "uid": "PBFA97CFB590B2093" }
+    },
+    {
+      "type": "bargauge",
+      "title": "Packets Received by Type",
+      "gridPos": { "h": 8, "w": 8, "x": 16, "y": 12 },
+      "targets": [
+        { "expr": "sum by (type) (amie_packets_received_total)", "legendFormat": "{{type}}" }
+      ],
+      "fieldConfig": { "defaults": { "thresholds": { "steps": [{ "color": "blue", "value": null }] } } },
+      "options": { "displayMode": "gradient", "orientation": "horizontal", "showUnfilled": true },
+      "datasource": { "type": "prometheus", "uid": "PBFA97CFB590B2093" }
+    },
+    {
+      "type": "timeseries",
+      "title": "Poller: Packets Fetched per Cycle",
+      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 20 },
+      "targets": [
+        { "expr": "rate(amie_poller_packets_fetched_total[5m]) * 60", "legendFormat": "Packets/min" }
+      ],
+      "fieldConfig": { "defaults": { "custom": { "drawStyle": "bars", "lineWidth": 1, "fillOpacity": 50 }, "color": { "fixedColor": "purple", "mode": "fixed" } } },
+      "datasource": { "type": "prometheus", "uid": "PBFA97CFB590B2093" }
+    },
+    {
+      "type": "timeseries",
+      "title": "Processing Duration (p50 / p95 / p99)",
+      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 20 },
+      "targets": [
+        { "expr": "histogram_quantile(0.50, sum by (le) (rate(amie_packet_processing_duration_seconds_bucket[5m])))", "legendFormat": "p50" },
+        { "expr": "histogram_quantile(0.95, sum by (le) (rate(amie_packet_processing_duration_seconds_bucket[5m])))", "legendFormat": "p95" },
+        { "expr": "histogram_quantile(0.99, sum by (le) (rate(amie_packet_processing_duration_seconds_bucket[5m])))", "legendFormat": "p99" }
+      ],
+      "fieldConfig": { "defaults": { "unit": "s", "custom": { "drawStyle": "line", "lineWidth": 2, "fillOpacity": 10 } } },
+      "options": { "tooltip": { "mode": "multi" }, "legend": { "displayMode": "table", "placement": "bottom", "calcs": ["lastNotNull"] } },
+      "datasource": { "type": "prometheus", "uid": "PBFA97CFB590B2093" }
+    },
+    {
+      "type": "table",
+      "title": "Processed Count by Type & Outcome",
+      "gridPos": { "h": 8, "w": 24, "x": 0, "y": 28 },
+      "targets": [
+        { "expr": "sum by (type, outcome) (amie_packets_processed_total)", "legendFormat": "{{type}} — {{outcome}}", "format": "table", "instant": true }
+      ],
+      "transformations": [
+        { "id": "organize", "options": { "excludeByName": { "Time": true }, "renameByName": { "type": "Packet Type", "outcome": "Outcome", "Value": "Count" } } }
+      ],
+      "fieldConfig": { "overrides": [
+        { "matcher": { "id": "byName", "options": "Outcome" }, "properties": [{ "id": "custom.cellOptions", "value": { "type": "color-text" } }, { "id": "mappings", "value": [{ "type": "value", "options": { "succeeded": { "color": "green", "text": "Succeeded" }, "permanently_failed": { "color": "red", "text": "Failed" }, "retry_scheduled": { "color": "orange", "text": "Retried" } } }] }] }
+      ] },
+      "datasource": { "type": "prometheus", "uid": "PBFA97CFB590B2093" }
+    }
+  ],
+  "refresh": "10s",
+  "schemaVersion": 39,
+  "tags": ["custos", "amie", "access-ci"],
+  "templating": { "list": [] },
+  "time": { "from": "now-1h", "to": "now" },
+  "timepicker": {},
+  "timezone": "browser",
+  "title": "ACCESS CI — AMIE Packet Processing",
+  "uid": "custos-amie-overview",
+  "version": 1
+}

--- a/compose/grafana/dashboards/amie-service.json
+++ b/compose/grafana/dashboards/amie-service.json
@@ -9,7 +9,7 @@
       "type": "stat",
       "title": "Total Packets Received",
       "gridPos": { "h": 4, "w": 6, "x": 0, "y": 0 },
-      "targets": [{ "expr": "sum(amie_packets_received_total)", "legendFormat": "Total" }],
+      "targets": [{ "expr": "round(sum(increase(amie_packets_received_total[$__range])))", "legendFormat": "Total" }],
       "fieldConfig": { "defaults": { "thresholds": { "steps": [{ "color": "blue", "value": null }] } } },
       "options": { "colorMode": "background", "textMode": "value_and_name" },
       "datasource": { "type": "prometheus", "uid": "PBFA97CFB590B2093" }
@@ -18,7 +18,7 @@
       "type": "stat",
       "title": "Packets Succeeded",
       "gridPos": { "h": 4, "w": 6, "x": 6, "y": 0 },
-      "targets": [{ "expr": "sum(amie_packets_processed_total{outcome=\"succeeded\"})", "legendFormat": "Succeeded" }],
+      "targets": [{ "expr": "round(sum(increase(amie_packets_processed_total{outcome=\"succeeded\"}[$__range])))", "legendFormat": "Succeeded" }],
       "fieldConfig": { "defaults": { "thresholds": { "steps": [{ "color": "green", "value": null }] } } },
       "options": { "colorMode": "background", "textMode": "value_and_name" },
       "datasource": { "type": "prometheus", "uid": "PBFA97CFB590B2093" }
@@ -27,7 +27,7 @@
       "type": "stat",
       "title": "Packets Failed",
       "gridPos": { "h": 4, "w": 6, "x": 12, "y": 0 },
-      "targets": [{ "expr": "sum(amie_packets_processed_total{outcome=~\"permanently_failed|failed\"})", "legendFormat": "Failed" }],
+      "targets": [{ "expr": "round(sum(increase(amie_packets_processed_total{outcome=~\"permanently_failed|failed\"}[$__range])))", "legendFormat": "Failed" }],
       "fieldConfig": { "defaults": { "thresholds": { "steps": [{ "color": "green", "value": null }, { "color": "red", "value": 1 }] } } },
       "options": { "colorMode": "background", "textMode": "value_and_name" },
       "datasource": { "type": "prometheus", "uid": "PBFA97CFB590B2093" }
@@ -36,7 +36,7 @@
       "type": "stat",
       "title": "Retries",
       "gridPos": { "h": 4, "w": 6, "x": 18, "y": 0 },
-      "targets": [{ "expr": "sum(amie_events_retry_total) or vector(0)", "legendFormat": "Retries" }],
+      "targets": [{ "expr": "round(sum(increase(amie_events_retry_total[$__range]))) or vector(0)", "legendFormat": "Retries" }],
       "fieldConfig": { "defaults": { "thresholds": { "steps": [{ "color": "green", "value": null }, { "color": "orange", "value": 1 }, { "color": "red", "value": 5 }] } } },
       "options": { "colorMode": "background", "textMode": "value_and_name" },
       "datasource": { "type": "prometheus", "uid": "PBFA97CFB590B2093" }
@@ -69,7 +69,7 @@
       "title": "Packets by Type",
       "gridPos": { "h": 8, "w": 8, "x": 0, "y": 12 },
       "targets": [
-        { "expr": "sum by (type) (amie_packets_received_total)", "legendFormat": "{{type}}" }
+        { "expr": "round(sum by (type) (increase(amie_packets_received_total[$__range])))", "legendFormat": "{{type}}" }
       ],
       "options": { "legend": { "displayMode": "table", "placement": "right", "values": ["value", "percent"] }, "pieType": "donut" },
       "datasource": { "type": "prometheus", "uid": "PBFA97CFB590B2093" }
@@ -79,7 +79,7 @@
       "title": "Processing Outcomes",
       "gridPos": { "h": 8, "w": 8, "x": 8, "y": 12 },
       "targets": [
-        { "expr": "sum by (outcome) (amie_packets_processed_total)", "legendFormat": "{{outcome}}" }
+        { "expr": "round(sum by (outcome) (increase(amie_packets_processed_total[$__range])))", "legendFormat": "{{outcome}}" }
       ],
       "fieldConfig": { "overrides": [
         { "matcher": { "id": "byName", "options": "succeeded" }, "properties": [{ "id": "color", "value": { "fixedColor": "green", "mode": "fixed" } }] },
@@ -94,7 +94,7 @@
       "title": "Packets Received by Type",
       "gridPos": { "h": 8, "w": 8, "x": 16, "y": 12 },
       "targets": [
-        { "expr": "sum by (type) (amie_packets_received_total)", "legendFormat": "{{type}}" }
+        { "expr": "round(sum by (type) (increase(amie_packets_received_total[$__range])))", "legendFormat": "{{type}}" }
       ],
       "fieldConfig": { "defaults": { "thresholds": { "steps": [{ "color": "blue", "value": null }] } } },
       "options": { "displayMode": "gradient", "orientation": "horizontal", "showUnfilled": true },
@@ -128,7 +128,7 @@
       "title": "Processed Count by Type & Outcome",
       "gridPos": { "h": 8, "w": 24, "x": 0, "y": 28 },
       "targets": [
-        { "expr": "sum by (type, outcome) (amie_packets_processed_total)", "legendFormat": "{{type}} — {{outcome}}", "format": "table", "instant": true }
+        { "expr": "round(sum by (type, outcome) (increase(amie_packets_processed_total[$__range])))", "legendFormat": "{{type}} — {{outcome}}", "format": "table", "instant": true }
       ],
       "transformations": [
         { "id": "organize", "options": { "excludeByName": { "Time": true }, "renameByName": { "type": "Packet Type", "outcome": "Outcome", "Value": "Count" } } }

--- a/compose/grafana/provisioning/dashboards/dashboards.yml
+++ b/compose/grafana/provisioning/dashboards/dashboards.yml
@@ -1,0 +1,12 @@
+apiVersion: 1
+
+providers:
+  - name: 'Custos'
+    orgId: 1
+    folder: 'Custos'
+    type: file
+    disableDeletion: false
+    editable: true
+    options:
+      path: /var/lib/grafana/dashboards
+      foldersFromFilesStructure: false

--- a/compose/grafana/provisioning/datasources/prometheus.yml
+++ b/compose/grafana/provisioning/datasources/prometheus.yml
@@ -1,0 +1,9 @@
+apiVersion: 1
+
+datasources:
+  - name: Prometheus
+    type: prometheus
+    access: proxy
+    url: http://prometheus:9090
+    isDefault: true
+    editable: false

--- a/compose/prometheus/prometheus.yml
+++ b/compose/prometheus/prometheus.yml
@@ -1,0 +1,18 @@
+global:
+  scrape_interval: 15s
+  evaluation_interval: 15s
+
+scrape_configs:
+  - job_name: 'access-ci-service'
+    metrics_path: '/actuator/prometheus'
+    static_configs:
+      - targets: ['host.docker.internal:8083']
+        labels:
+          service: 'access-ci-service'
+
+  - job_name: 'custos-signer'
+    metrics_path: '/metrics'
+    static_configs:
+      - targets: ['host.docker.internal:8084']
+        labels:
+          service: 'custos-signer'

--- a/pom.xml
+++ b/pom.xml
@@ -141,6 +141,11 @@
                 <artifactId>jakarta.ws.rs-api</artifactId>
                 <version>${jakarta.ws.version}</version>
             </dependency>
+            <dependency>
+                <groupId>net.logstash.logback</groupId>
+                <artifactId>logstash-logback-encoder</artifactId>
+                <version>${logstash.logback.version}</version>
+            </dependency>
         </dependencies>
     </dependencyManagement>
 
@@ -204,6 +209,7 @@
 
         <ssh.username>ubuntu</ssh.username>
         <jakarta.ws.version>4.0.0</jakarta.ws.version>
+        <logstash.logback.version>7.4</logstash.logback.version>
         <custos.dist.name>apache-airavata-custos-${project.version}</custos.dist.name>
         <access.service.dist.name>apache-airavata-custos-access-ci-service-${project.version}</access.service.dist.name>
     </properties>


### PR DESCRIPTION
This PR introduces,
* The Audit logs for the AMIE service and exposes the metrics through a Grafana dashboard
* Persist the DN lists from the data_project_create and data_account_create AMIE packets
* And Bug fixes
  - Duplicate cluster accounts created on handler retry or AMIE reactivation --> (now idempotent)
  - Infinite retry loop when handler exceptions mark transaction rollback-only -->  now fails safely with exponential backoff and max 3 attempts
  - request_user_modify failed due to wrong AMIE field names and wiped existing data on absent fields
  - Account inactivate/reactivate succeeded silently when no matching records existed

<img width="2561" height="1318" alt="Screenshot 2026-03-27 at 2 36 05 PM" src="https://github.com/user-attachments/assets/9c7469b8-7725-45a3-85c4-0d3a923c6247" />

