### PR TITLE
docs: security track research notes — identity platforms, authorization engines, and Zanzibar

### DIFF
--- a/docs/security-research/README.md
+++ b/docs/security-research/README.md
@@ -1,0 +1,21 @@
+# Security Track Research — Dynamic Access Policy & Enforcement Engine
+
+**Contributor:** Temitope Aderibigbe  
+**Georgia Tech VIP Program | Spring 2026**  
+**Related Issue:** [AIRAVATA-3978](https://issues.apache.org/jira/browse/AIRAVATA-3978)
+
+## Overview
+
+This directory contains research conducted on the security track for Apache Airavata Custos, focused on informing the design of a Dynamic Access Policy & Enforcement Engine (Project 2). The research covers identity and authentication platform analysis, authorization engine patterns, and a deep dive into Google's Zanzibar authorization system.
+
+## Documents
+
+- [`identity-platform-notes.md`](./identity-platform-notes.md) — Research notes on six identity/authentication platforms: Auth0, WorkOS, WSO2 Asgardeo, Amazon Cognito, Eggshell, and Keycloak. Covers core features, architecture, and user-facing authorization engine for each.
+- [`zanzibar-paper-notes.md`](./zanzibar-paper-notes.md) — Notes on the Google Zanzibar paper (USENIX ATC 2019), covering the relation tuple data model, consistency model, API, system architecture, and direct relevance to Custos Project 2.
+
+## Key Findings
+
+- Custos currently handles authentication via Keycloak but has no general-purpose authorization engine for attribute or policy-based access decisions
+- Among platforms reviewed, only Keycloak and WorkOS FGA offer true engine-side enforcement — the rest rely on application-side token claim checking
+- Zanzibar's relation tuple model and per-namespace policy configs directly map to Project 2's requirements for per-tenant policies and a centralized policy decision service
+- Tools like Open Policy Agent (OPA) and AWS Cedar are strong candidates as the policy evaluation engine for Project 2

--- a/docs/security-research/identity-platform-notes.md
+++ b/docs/security-research/identity-platform-notes.md
@@ -1,0 +1,192 @@
+# Identity & Authentication Platform Notes
+
+**Contributor:** Temitope Aderibigbe  
+**Georgia Tech VIP Program | Spring 2026**  
+
+---
+
+## Overview
+
+Research notes on six identity and authentication platforms relevant to the Custos security stack. For each platform, this document covers core features, architectural design, and how user-facing authorization is handled — specifically where enforcement occurs (application-side token claim checking vs. dedicated policy engine).
+
+---
+
+## 1. Auth0
+
+**Type:** Identity-as-a-Service (IDaaS) — Cloud-Native Authentication Platform
+
+### Overview
+Auth0 is a cloud-based Identity-as-a-Service platform developed by Okta. It provides developers with drop-in authentication and authorization solutions, abstracting the complexity of identity management behind simple APIs and SDKs. It is designed for ease of integration across web, mobile, and API-based applications.
+
+### Core Features & Function
+- Universal Login: Centralized, customizable login page hosted by Auth0
+- Social & Enterprise SSO: Pre-built connections to 30+ identity providers (Google, GitHub, SAML, LDAP, AD)
+- Multi-Factor Authentication (MFA): Built-in support for TOTP, SMS, push, and WebAuthn
+- Role-Based Access Control (RBAC): Fine-grained permissions management via roles and scopes
+- Machine-to-Machine (M2M) Auth: Client Credentials flow for API-to-API communication
+- Anomaly Detection: Automatic blocking of suspicious login attempts and credential stuffing
+- Rules & Actions: JavaScript hooks injected into the authentication pipeline for custom logic
+- Auth0 Management API: Programmatic management of users, connections, and applications
+
+### How It Works (Architecture)
+- Auth0 operates as a central Authorization Server following OAuth 2.0 and OpenID Connect (OIDC) standards
+- Tenant model: Each organization gets an isolated tenant — a dedicated Auth0 environment with its own user store, settings, and connections
+- Authentication flow: Users are redirected to Auth0's Universal Login page → Auth0 verifies credentials → issues JWT access tokens and ID tokens → tokens are returned to the client app
+- Extensibility pipeline: Actions are Node.js functions that execute at specific points in the token issuance flow, allowing injection of custom claims or external API calls
+- Token format: Issues JWT-based access tokens signed with RS256 or HS256. JWKS endpoints allow downstream services to validate tokens
+- Deployment: Primarily SaaS with a Private Cloud option for enterprises needing data residency
+
+### Authorization Engine (User-Facing)
+- Authorization is built around roles and permissions embedded into the JWT access token at login time
+- Enforcement is entirely application-side — Auth0 does not sit in the request path after token issuance
+- Actions allow custom authorization behavior at token issuance time (e.g., blocking a token if a user lacks a required attribute)
+- No dedicated runtime authorization engine — all authorization context is baked into the token at login
+
+---
+
+## 2. WorkOS
+
+**Type:** Enterprise SSO & Directory Sync Infrastructure for B2B SaaS
+
+### Overview
+WorkOS is a developer-focused platform providing enterprise-grade authentication features as building blocks — primarily SAML SSO, SCIM Directory Sync, and Magic Auth. Purpose-built for B2B SaaS companies that need to integrate with enterprise customers' existing identity infrastructure without managing those integrations themselves.
+
+### Core Features & Function
+- Single Sign-On (SSO): SAML 2.0 and OIDC connections to enterprise IdPs like Okta, Azure AD, Ping
+- Directory Sync (SCIM): Automated user provisioning/deprovisioning from enterprise directories
+- Magic Auth: Passwordless login via one-time email links
+- Admin Portal: Self-service configuration UI embeddable in your app for enterprise customers
+- Fine-Grained Authorization (FGA): ReBAC engine for complex permission modeling inspired by Google Zanzibar
+- Audit Logs: Structured event log stream for compliance and monitoring
+
+### How It Works (Architecture)
+- WorkOS acts as an intermediary broker between your application and enterprise identity providers
+- SSO flow: App redirects to WorkOS → WorkOS initiates SAML/OIDC flow with customer IdP → normalized profile returned to app → backend exchanges code for user profile via WorkOS API
+- Directory Sync: Receives SCIM 2.0 push events from enterprise directories and exposes a unified events API
+- FGA: Permissions modeled as relationships between objects (e.g., user → viewer → document). Engine evaluates relationship graphs to answer authorization queries
+- Stateless architecture: Issues short-lived tokens/codes and leaves session management to the application
+
+### Authorization Engine (User-Facing)
+- Two distinct layers: basic role system (application-side) and Fine-Grained Authorization (engine-side)
+- FGA is a dedicated server-side Policy Decision Point — the application sends a check request and the engine returns allow/deny based on a relationship graph
+- One of the few platforms reviewed with a true runtime authorization service operating independently of token claims
+- Directory group memberships from enterprise IdPs feed into FGA relationship definitions
+
+---
+
+## 3. WSO2 Asgardeo
+
+**Type:** Cloud-Native CIAM (Customer Identity & Access Management) by WSO2
+
+### Overview
+Asgardeo is a SaaS CIAM platform built by WSO2, the same company behind WSO2 Identity Server. Designed for organizations building consumer-facing or B2B applications that need identity features without hosting an identity server themselves.
+
+### Core Features & Function
+- Standard Protocol Support: OAuth 2.0, OIDC, SAML 2.0, WS-Federation
+- Social Login: Google, GitHub, Facebook, Microsoft, Apple and more via federation
+- Multi-Factor Authentication: TOTP, SMS OTP, email OTP, FIDO2/WebAuthn (passkeys)
+- Adaptive Authentication: JavaScript-based policy engine to dynamically step up authentication based on context
+- SCIM 2.0 User Management: Standard API for provisioning and managing users programmatically
+- B2B Organization Management: Hierarchical org model for managing sub-tenants with delegated admin
+
+### How It Works (Architecture)
+- Multi-tenant SaaS deployment of WSO2 Identity Server — each customer organization gets an isolated root organization
+- Visual, flow-based authentication designer where admins configure login steps graphically
+- Adaptive authentication: JavaScript sandbox executes policies per-login evaluating IP, device, or risk score
+- Token issuance: Follows OIDC/OAuth 2.0 flows, issuing JWTs signed with per-organization keys
+- B2B model: Root organizations can create child organizations with their own IdP configs and user pools
+
+### Authorization Engine (User-Facing)
+- Authorization handled through application roles and user groups embedded into JWT claims at token issuance
+- No standalone runtime authorization engine — enforcement is fully application-side
+- Supports OAuth 2.0 scopes for API-level access control validated by backend services or API gateways
+- Adaptive authentication scripts run at login time only — not per-request resource-level authorization
+
+---
+
+## 4. Amazon Cognito
+
+**Type:** AWS-Native Identity Service for Web and Mobile Applications
+
+### Overview
+Amazon Cognito is AWS's managed identity service providing two core constructs: User Pools (identity provider and user directory) and Identity Pools (for granting AWS resource access). Integrates deeply with the AWS ecosystem.
+
+### Core Features & Function
+- User Pools: Managed user directory with sign-up, sign-in, password policies, and MFA
+- Identity Pools: Exchange tokens from any IdP for temporary AWS IAM credentials
+- Social & SAML/OIDC Federation: Integrate external identity providers into User Pools
+- Lambda Triggers: Hook into authentication lifecycle events via AWS Lambda
+- Groups & RBAC: User groups with IAM role mappings for coarse-grained access control
+
+### How It Works (Architecture)
+- User Pools: OIDC-compliant identity provider issuing JWTs (ID token, access token, refresh token)
+- Identity Pools: Accept tokens from any trusted provider and exchange them for temporary AWS IAM credentials via AWS STS
+- Lambda Triggers: Called at lifecycle points (pre-signup, post-confirmation, pre/post authentication, token customization) as the primary extensibility mechanism
+- AWS-native integration: Integrates with API Gateway, ALB, AppSync, and IAM
+
+### Authorization Engine (User-Facing)
+- Authorization handled through User Pool Groups — group names embedded in the ID token under the `cognito:groups` claim
+- No dedicated authorization engine — enforcement is application-side or via AWS service integrations (API Gateway Cognito Authorizers, IAM policies)
+- Identity Pools translate group memberships into temporary IAM credentials, making AWS IAM the enforcement layer for resource-level access
+- Lambda Triggers are the primary escape hatch for custom authorization logic
+
+---
+
+## 5. Eggshell Authentication
+
+**Type:** Lightweight, Open-Source Authentication Framework
+
+### Overview
+Eggshell Authentication is a lightweight, open-source authentication framework designed for simplicity and developer control. A self-hosted, code-first library for developers who want authentication primitives without the overhead of a full identity server.
+
+### Core Features & Function
+- Session & Token Management: JWT issuance and refresh token rotation
+- Password Hashing: Secure credential storage using bcrypt/argon2
+- OAuth 2.0 Client Support: Acts as an OAuth client for social login flows
+- Middleware Integrations: Plugs into common web frameworks as authentication middleware
+- Minimal Dependencies: Small footprint with explicit dependency management for auditability
+- Customizable Storage Adapters: Supports custom backends (SQL, NoSQL)
+
+### How It Works (Architecture)
+- Library-first architecture — runs embedded within the application process, not as a separate server
+- Provides discrete modules (token issuance, session management, password hashing, OAuth client) that developers compose into their own authentication flow
+- Token flow: Issues JWTs locally within the app. App controls signing keys, token lifetime, and claim structure directly
+- Adapter pattern for persistence — developers plug in their own database adapter
+
+### Authorization Engine (User-Facing)
+- No built-in authorization engine — purely an authentication library
+- Developer decides what claims to include (roles, groups, permissions) and how the application enforces them
+- No PEP, PDP, or policy layer — enforcement happens wherever the developer writes it in application code
+- Must be paired with a separate authorization library or policy engine for any meaningful access control
+
+---
+
+## 6. Keycloak
+
+**Type:** Open-Source Enterprise Identity & Access Management Server
+
+### Overview
+Keycloak is an open-source IAM solution developed by Red Hat providing a full-featured, self-hosted identity server. The most widely adopted open-source IAM platform and the identity provider used directly by Custos.
+
+### Core Features & Function
+- Single Sign-On & Single Logout: SSO across all applications within a realm
+- Standard Protocols: OAuth 2.0, OIDC, SAML 2.0, and LDAP/Active Directory federation
+- User Federation: Sync and authenticate users from external LDAP/AD directories
+- Fine-Grained Authorization: Policy-based authorization server with resource, scope, and policy definitions (UMA 2.0)
+- Multi-Tenancy via Realms: Isolated authentication domains within a single Keycloak instance
+- Themeable UI: Customizable login and registration pages via Freemarker templates
+
+### How It Works (Architecture)
+- Realm: Top-level organizational unit — a self-contained authentication domain. Custos uses realms to implement multi-tenancy, each science gateway tenant gets its own Keycloak realm
+- Clients: Applications requesting authentication are registered as clients with type (public, confidential, bearer-only), redirect URIs, and protocol settings
+- Token lifecycle: OAuth 2.0 Authorization Server and OIDC Provider issuing JWTs signed with realm-specific RSA key pairs
+- Authorization Services: Includes a Policy Enforcement Point (PEP) and Policy Decision Point (PDP) architecture for resource-level authorization
+- Deployment: Quarkus-based Java server. Custos runs Keycloak on port 8080
+- Custos relevance: Custos creates and manages Keycloak realms programmatically when tenants are initialized
+
+### Authorization Engine (User-Facing)
+- Most complete built-in authorization engine of all platforms reviewed — full PDP and PEP architecture via Authorization Services
+- Application-side enforcement: Roles and group memberships embedded in JWT via `realm_access.roles` and `resource_access.<client>.roles` claims — no additional server calls needed
+- Engine-side enforcement: Applications can query Keycloak at runtime, receiving an RPT (Requesting Party Token) reflecting what the user is authorized to access, evaluated server-side against defined policies
+- Policies can be role-based, user-based, group-based, JavaScript-based, or time-based, combined with AND/OR/NOT logic
+- Unique among platforms reviewed: supports both application-side and engine-side enforcement depending on complexity of the authorization requirement

--- a/docs/security-research/zanzibar-paper-notes.md
+++ b/docs/security-research/zanzibar-paper-notes.md
@@ -1,0 +1,149 @@
+# Zanzibar: Google's Consistent, Global Authorization System — Paper Notes
+
+**Contributor:** Temitope Aderibigbe  
+**Source:** USENIX ATC 2019 — Pang et al., Google  
+**Georgia Tech VIP Program | Spring 2026**  
+**Related Issue:** [AIRAVATA-3978](https://issues.apache.org/jira/browse/AIRAVATA-3978)
+
+---
+
+## 1. What Is Zanzibar?
+
+Zanzibar is Google's globally distributed authorization system — built to answer one core question at massive scale: "Does user U have permission to perform action R on object O?" It is not an authentication system; it is purely an authorization system that determines what an authenticated user is allowed to do.
+
+Zanzibar serves as the single unified access control layer for Google's major products including Calendar, Cloud, Drive, Maps, Photos, and YouTube. Rather than each product building its own permission system, they all delegate authorization decisions to Zanzibar through a shared RPC-based API.
+
+**Scale context:**
+- Stores over 2 trillion access control lists (ACLs)
+- Handles over 10 million authorization check requests per second
+- Maintains 95th-percentile latency under 10 milliseconds
+- Sustains 99.999% availability over 3+ years of production use
+- Data replicated across 30+ geographic locations worldwide
+
+---
+
+## 2. The Core Data Model — Relation Tuples
+
+Zanzibar's entire authorization model is built on a single primitive: the **relation tuple**. Every permission is expressed as:
+
+object#relation@user
+
+This reads as: "user has relation to object." Examples:
+
+| Tuple | Semantics |
+|---|---|
+| `doc:readme#owner@10` | User 10 is an owner of doc:readme |
+| `group:eng#member@11` | User 11 is a member of group:eng |
+| `doc:readme#viewer@group:eng#member` | Members of group:eng are viewers of doc:readme |
+| `doc:readme#parent@folder:A` | doc:readme is in folder:A (used for inheritance) |
+
+A key design insight: the `@user` part can itself be an object-relation pair, not just an individual user. This allows ACLs to reference groups and groups to reference other groups — enabling nested group membership and ACL inheritance without storing a separate tuple per object.
+
+Groups are not a special concept in Zanzibar — they are just ACLs where the object is a group and the relation is semantically "member."
+
+---
+
+## 3. Namespace Configuration & Userset Rewrites
+
+Before storing relation tuples, clients define a **namespace configuration** — a logical grouping for a type of object (e.g., `doc`, `folder`, `video`). Each namespace defines its relations and how those relations interact.
+
+### Userset Rewrite Rules
+
+Userset rewrite rules define object-agnostic relationships between relations — for example, "all editors are also viewers." The rule is defined once in the namespace config and applied at evaluation time rather than storing redundant tuples.
+
+Three key primitives:
+
+- **`this`** — Returns all users directly stored for that object-relation pair, including indirect userset references. Default behavior.
+- **`computed_userset`** — Derives a userset from another relation on the same object. Example: viewer relation includes the editor userset, so all editors are automatically viewers.
+- **`tuple_to_userset`** — Looks up a related object via a tupleset, then computes a userset from that object. This is how folder-level permissions are inherited by documents.
+
+These primitives combine with union, intersection, and exclusion operators to express complex policies compactly.
+
+---
+
+## 4. Consistency Model — The "New Enemy" Problem
+
+Authorization systems face a subtle consistency challenge: if a user is removed from an ACL, they should immediately lose access — even to new content being added around the same time. Zanzibar calls this the **"new enemy" problem**.
+
+**Example A (ACL update order):** Alice removes Bob from a folder ACL, then asks Charlie to add new documents. If the ACL check doesn't respect the ordering, Bob could see the new documents using the stale old ACL.
+
+**Example B (Old ACL on new content):** Alice removes Bob from a document ACL, then Charlie adds new content. If evaluated against a stale snapshot, Bob could see content he was already removed from.
+
+### Zookies — The Consistency Token
+
+Zanzibar solves this with a **zookie** — an opaque consistency token encoding a globally meaningful timestamp:
+
+1. When content is modified, the client requests a zookie via a content-change check. Zanzibar encodes a current global timestamp.
+2. The client stores the zookie alongside the content in the same atomic write.
+3. Subsequent ACL checks include the zookie — telling Zanzibar to evaluate at a snapshot no older than that timestamp.
+4. This guarantees the ACL check always sees state at least as fresh as the content.
+
+The zookie protocol provides at-least-as-fresh semantics without requiring global synchronization on every check. Most checks are served from locally replicated data; only very recent zookies require cross-region round trips.
+
+The underlying storage is Google Spanner, which provides external consistency via its TrueTime mechanism.
+
+---
+
+## 5. The Zanzibar API
+
+| Operation | Description |
+|---|---|
+| **Read** | Retrieves raw relation tuples matching a tupleset. Does not follow userset rewrite rules. Used to display ACLs or group memberships. |
+| **Write** | Adds or removes a single relation tuple. Bulk modifications use read-modify-write with optimistic concurrency control. |
+| **Check** | Core operation. Given a userset (`object#relation`), a user, and a zookie — returns whether the user has that relation to the object. |
+| **Expand** | Returns the full effective userset for an object-relation pair, following all rewrite rules recursively. Used to build access-controlled search indices. |
+| **Watch** | Streams tuple modification events in timestamp order. Used by clients maintaining secondary indices. |
+
+---
+
+## 6. System Architecture
+
+### aclservers
+The main server type. Handle Check, Read, Expand, and Write requests. Fan out work to other servers as needed (e.g., recursive group membership traversal). Results gathered and returned to client.
+
+### watchservers
+Specialized servers that tail the changelog and stream namespace changes to clients in near real time via the Watch API.
+
+### Spanner
+The underlying globally distributed database. Stores relation tuples, namespace configurations, and the changelog. Each namespace gets its own Spanner database. TrueTime provides external consistency guarantees that make zookies meaningful.
+
+### Leopard Indexing System
+A specialized index for deeply nested and widely expanded group membership. Standard recursive pointer chasing breaks down for large groups. Leopard addresses this by:
+
+- Maintaining an offline index flattening group-to-group paths (`GROUP2GROUP`) and user-to-group memberships (`MEMBER2GROUP`)
+- Answering membership as set intersection: "Is user U a member of group G?" → "Is `MEMBER2GROUP(U) ∩ GROUP2GROUP(G)` non-empty?"
+- Maintaining an incremental online layer applying tuple changes in real time on top of the offline snapshot
+
+---
+
+## 7. Performance Techniques
+
+### Distributed Cache
+Servers form a distributed cache using consistent hashing. Cache keys encode snapshot timestamps. Timestamp quantization (rounding to 1 or 10 second granularity) allows the vast majority of checks to share the same evaluation snapshot and cache results.
+
+### Hot Spot Mitigation
+- Distributed cache with consistent hashing to spread load
+- Lock tables to deduplicate simultaneous requests for the same cache key
+- Cache prefetching for super-hot objects
+- Delayed cancellation of secondary checks when concurrent requests are waiting
+
+### Request Hedging
+For Spanner and Leopard calls, Zanzibar sends the same request to multiple servers and uses whichever responds first. Deferred until the initial request is known to be slow to limit extra traffic.
+
+### Performance Isolation
+Each client has a global CPU quota. Per-object and per-client concurrency limits on Spanner prevent any single object or client from monopolizing backend resources.
+
+---
+
+## 8. Relevance to Custos & Project 2
+
+Lahiru assigned this paper in the context of the **Dynamic Access Policy & Enforcement Engine (Project 2)** for Custos. The connection is direct:
+
+- **Zanzibar is the canonical example of engine-side authorization** — a dedicated Policy Decision Point (PDP) that applications call at runtime rather than embedding authorization logic in token claims
+- **WorkOS FGA**, noted in the platform research as one of the only engine-side systems reviewed, is directly modeled on Zanzibar's relation tuple approach
+- **Project 2 calls for** a "policy decision service that other Custos components call to answer: should this user be allowed to do this action on this resource, right now?" — this is precisely the role Zanzibar plays for Google's services
+- **Zanzibar's namespace configs** map directly to Project 2's per-tenant policy sets — each Custos tenant (science gateway) defining their own policy set evaluated by a shared engine
+- **The audit trail requirement** in Project 2 mirrors Zanzibar's changelog and Watch API, which provide a durable record of all ACL changes for compliance reporting
+- **Tools like Open Policy Agent (OPA) and AWS Cedar** are strong candidates as the policy evaluation engine for Project 2, rather than building one from scratch
+
+**Key takeaway:** Zanzibar demonstrates that authorization should be a dedicated service separate from authentication. The question for Custos Project 2 is what subset of Zanzibar's ideas are appropriate for the research computing context and which existing policy engine tools best fit that use case.


### PR DESCRIPTION
## Summary

This PR adds research documentation produced during the Spring 2026 Georgia Tech VIP Program security track for Apache Airavata Custos.

## Related Issue
AIRAVATA-3978: https://issues.apache.org/jira/browse/AIRAVATA-3978

## Changes
- `docs/security-research/README.md` — Overview of the security track research scope and key findings
- `docs/security-research/identity-platform-notes.md` — Research notes on six identity/authentication platforms (Auth0, WorkOS, WSO2 Asgardeo, Amazon Cognito, Eggshell, Keycloak) covering core features, architecture, and user-facing authorization engine patterns
- `docs/security-research/zanzibar-paper-notes.md` — Notes on the Google Zanzibar paper (USENIX ATC 2019) covering the relation tuple data model, consistency model, API, system architecture, and direct relevance to Custos Project 2 (Dynamic Access Policy & Enforcement Engine)

## Key Findings
- Custos currently handles authentication via Keycloak but has no general-purpose authorization engine for attribute or policy-based access decisions
- Among platforms reviewed, only Keycloak and WorkOS FGA offer true engine-side enforcement — the rest rely on application-side token claim checking
- Zanzibar's relation tuple model and per-namespace policy configs directly map to Project 2's requirements for per-tenant policies and a centralized policy decision service
- Open Policy Agent (OPA) and AWS Cedar are strong candidates as the policy evaluation engine for Project 2