### PR TITLE
[INFRA] Set up default rulesets for default and release branches

### DIFF
--- a/.asf.yaml
+++ b/.asf.yaml
@@ -17,11 +17,11 @@
 # under the License.
 #
 notifications:
-  commits:              commits@airavata.apache.org
+  commits: commits@airavata.apache.org
   # Send all issue emails (new, closed, comments) to issues@
-  issues:               issues@airavata.apache.org
+  issues: issues@airavata.apache.org
   # Send new/closed PR notifications to dev@
-  pullrequests_status:  custos@airavata.apache.org
+  pullrequests_status: custos@airavata.apache.org
   # Send individual PR comments/reviews to issues@
   pullrequests_comment: issues@airavata.apache.org
 
@@ -41,3 +41,16 @@ github:
     wiki: false
     issues: true
     projects: true
+  rulesets:
+    - name: "Default Branch Protection"
+      type: branch
+      branches:
+        includes:
+          - "~DEFAULT_BRANCH"
+          - "release/*"
+          - "rel/*"
+        excludes: []
+      bypass_teams:
+        - root
+      restrict_deletion: true
+      restrict_force_push: true


### PR DESCRIPTION
This Pull Request enables the repository to conform with the "sane default security settings" of the Apache Software Foundation by configuring a default branch ruleset that protects the default branch and any release branches.

Note that `~DEFAULT_BRANCH` is a GitHub symbolic link to the current default branch (HEAD) of the repository and does not need changing.
If the managing project does not wish to set up these defaults, please close this Pull Request. Alternatively, the project may merge this Pull Request to apply the changes immediately.

If no action is taken, this Pull Request will be automatically merged by the Apache Infrastructure team on **2026-05-29** (14 days from now).

For any further information, please reach us on Slack or at: users@infra.apache.org
