### PR TITLE
Validate API request bodies and domain inputs

### DIFF
--- a/docs/API-Docs.md
+++ b/docs/API-Docs.md
@@ -6,7 +6,7 @@ HTTP/JSON API exposed by `cmd/server`. All endpoints accept and return
 - **Base URL:** `http://<host>:<port>` (default port `8080`, configurable via `HTTP_ADDR`)
 - **Auth:** none currently enforced (deploy behind a trusted ingress / auth proxy)
 - **Content-Type:** `application/json` is required on every request that has a body
-- **Unknown fields:** request bodies with unknown JSON fields are rejected with `400`
+- **Unknown fields / extra JSON values:** request bodies with unknown fields or trailing JSON data are rejected with `400`
 
 ---
 
@@ -31,7 +31,7 @@ Errors are returned with an appropriate HTTP status code and a JSON body:
 
 | Status | Meaning | Triggered by |
 |--------|---------|--------------|
-| `400 Bad Request` | Malformed JSON, unknown field, missing required field, or unknown foreign-key reference | request body validation, `service.ErrInvalidInput` |
+| `400 Bad Request` | Malformed JSON, missing `application/json` content type, unknown field, trailing JSON data, missing required field, or unknown foreign-key reference | request body validation, `service.ErrInvalidInput` |
 | `404 Not Found` | Requested record does not exist | `service.ErrNotFound` |
 | `409 Conflict` | Duplicate `email` or duplicate `originated_id` | `service.ErrAlreadyExists` |
 | `500 Internal Server Error` | Unexpected server / database failure (driver message is logged, never returned) | any other error |

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -21,10 +21,15 @@ package server
 import (
 	"encoding/json"
 	"errors"
+	"fmt"
+	"io"
 	"log/slog"
+	"mime"
 	"net/http"
 	"strings"
 	"time"
+
+	"github.com/go-sql-driver/mysql"
 
 	"github.com/apache/airavata-custos/pkg/models"
 	"github.com/apache/airavata-custos/pkg/service"
@@ -49,6 +54,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 }
 
 func (s *Server) routes() {
+	s.mux.HandleFunc("GET /{$}", s.index)
 	s.mux.HandleFunc("GET /healthz", s.healthz)
 
 	s.mux.HandleFunc("POST /organizations", s.createOrganization)
@@ -143,6 +149,14 @@ func (s *Server) routes() {
 	s.mux.HandleFunc("GET /user-identities/oidc-subjects/{oidcSub}", s.getUserIdentityByOIDCSub)
 	s.mux.HandleFunc("GET /users/{id}/user-identities", s.listUserIdentitiesForUser)
 
+}
+
+func (s *Server) index(w http.ResponseWriter, _ *http.Request) {
+	writeJSON(w, http.StatusOK, map[string]any{
+		"name":          "Apache Airavata Custos API",
+		"health":        "/healthz",
+		"documentation": "docs/API-Docs.md",
+	})
 }
 
 func (s *Server) healthz(w http.ResponseWriter, _ *http.Request) {
@@ -1023,9 +1037,27 @@ func (r *statusRecorder) WriteHeader(code int) {
 }
 
 func decodeJSON(r *http.Request, dst any) error {
+	contentType := r.Header.Get("Content-Type")
+	if contentType == "" {
+		return errors.New("Content-Type must be application/json")
+	}
+	mediaType, _, err := mime.ParseMediaType(contentType)
+	if err != nil || mediaType != "application/json" {
+		return errors.New("Content-Type must be application/json")
+	}
+
 	dec := json.NewDecoder(r.Body)
 	dec.DisallowUnknownFields()
-	return dec.Decode(dst)
+	if err := dec.Decode(dst); err != nil {
+		return err
+	}
+	if err := dec.Decode(&struct{}{}); !errors.Is(err, io.EOF) {
+		if err == nil {
+			return errors.New("request body must contain a single JSON value")
+		}
+		return fmt.Errorf("invalid trailing data after JSON value: %w", err)
+	}
+	return nil
 }
 
 func writeJSON(w http.ResponseWriter, status int, body any) {
@@ -1049,9 +1081,31 @@ func writeServiceError(w http.ResponseWriter, err error) {
 		writeError(w, http.StatusConflict, err)
 	case errors.Is(err, service.ErrInvalidInput):
 		writeError(w, http.StatusBadRequest, err)
+	case isDuplicateKeyError(err):
+		writeError(w, http.StatusConflict, service.ErrAlreadyExists)
+	case isInvalidConstraintError(err):
+		writeError(w, http.StatusBadRequest, service.ErrInvalidInput)
 	default:
 		// Avoid leaking driver messages to clients; log the full error.
 		slog.Error("internal server error", "error", err.Error())
 		writeError(w, http.StatusInternalServerError, errors.New(strings.TrimSpace("internal server error")))
+	}
+}
+
+func isDuplicateKeyError(err error) bool {
+	var mysqlErr *mysql.MySQLError
+	return errors.As(err, &mysqlErr) && mysqlErr.Number == 1062
+}
+
+func isInvalidConstraintError(err error) bool {
+	var mysqlErr *mysql.MySQLError
+	if !errors.As(err, &mysqlErr) {
+		return false
+	}
+	switch mysqlErr.Number {
+	case 1292, 1451, 1452:
+		return true
+	default:
+		return false
 	}
 }

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -1,0 +1,53 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package server
+
+import (
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+func TestDecodeJSONRequiresApplicationJSON(t *testing.T) {
+	req := httptest.NewRequest("POST", "/organizations", strings.NewReader(`{"name":"Example"}`))
+
+	var body map[string]string
+	if err := decodeJSON(req, &body); err == nil {
+		t.Fatal("expected missing Content-Type to be rejected")
+	}
+}
+
+func TestDecodeJSONRejectsTrailingData(t *testing.T) {
+	req := httptest.NewRequest("POST", "/organizations", strings.NewReader(`{"name":"Example"} {"x":1}`))
+	req.Header.Set("Content-Type", "application/json")
+
+	var body map[string]string
+	if err := decodeJSON(req, &body); err == nil {
+		t.Fatal("expected trailing JSON data to be rejected")
+	}
+}
+
+func TestDecodeJSONAcceptsApplicationJSONWithCharset(t *testing.T) {
+	req := httptest.NewRequest("POST", "/organizations", strings.NewReader(`{"name":"Example"}`))
+	req.Header.Set("Content-Type", "application/json; charset=utf-8")
+
+	var body map[string]string
+	if err := decodeJSON(req, &body); err != nil {
+		t.Fatalf("expected valid JSON body: %v", err)
+	}
+}

--- a/pkg/service/compute_allocation.go
+++ b/pkg/service/compute_allocation.go
@@ -42,11 +42,20 @@ func (s *Service) CreateComputeAllocation(ctx context.Context, alloc *models.Com
 	if alloc.ComputeClusterID == "" {
 		return nil, fmt.Errorf("%w: compute_cluster_id is required", ErrInvalidInput)
 	}
+	if alloc.InitialSUAmount < 0 {
+		return nil, fmt.Errorf("%w: initial_su_amount must be non-negative", ErrInvalidInput)
+	}
+	if err := validateRequiredTimeRange(alloc.StartTime, alloc.EndTime); err != nil {
+		return nil, err
+	}
 	if alloc.ID == "" {
 		alloc.ID = newID()
 	}
 	if alloc.Status == "" {
 		alloc.Status = models.ACTIVE
+	}
+	if err := validateAllocationStatus("status", alloc.Status); err != nil {
+		return nil, err
 	}
 
 	if proj, err := s.projs.FindByID(ctx, alloc.ProjectID); err != nil {
@@ -106,6 +115,24 @@ func (s *Service) ListComputeAllocationsByCluster(ctx context.Context, clusterID
 func (s *Service) UpdateComputeAllocation(ctx context.Context, alloc *models.ComputeAllocation) error {
 	if alloc == nil || alloc.ID == "" {
 		return fmt.Errorf("%w: compute allocation id is required", ErrInvalidInput)
+	}
+	if alloc.Name == "" {
+		return fmt.Errorf("%w: compute allocation name is required", ErrInvalidInput)
+	}
+	if alloc.ProjectID == "" {
+		return fmt.Errorf("%w: project_id is required", ErrInvalidInput)
+	}
+	if alloc.ComputeClusterID == "" {
+		return fmt.Errorf("%w: compute_cluster_id is required", ErrInvalidInput)
+	}
+	if alloc.InitialSUAmount < 0 {
+		return fmt.Errorf("%w: initial_su_amount must be non-negative", ErrInvalidInput)
+	}
+	if err := validateRequiredTimeRange(alloc.StartTime, alloc.EndTime); err != nil {
+		return err
+	}
+	if err := validateAllocationStatus("status", alloc.Status); err != nil {
+		return err
 	}
 	if err := s.inTx(ctx, func(tx *sql.Tx) error {
 		return s.allocs.Update(ctx, tx, alloc)

--- a/pkg/service/compute_allocation_change_request.go
+++ b/pkg/service/compute_allocation_change_request.go
@@ -40,6 +40,14 @@ func (s *Service) CreateComputeAllocationChangeRequest(ctx context.Context, req 
 	if req.RequesterID == "" {
 		return nil, fmt.Errorf("%w: requester_id is required", ErrInvalidInput)
 	}
+	if req.RequestedSUAmount < 0 {
+		return nil, fmt.Errorf("%w: requested_su_amount must be non-negative", ErrInvalidInput)
+	}
+	if req.RequestedStatus != "" {
+		if err := validateAllocationStatus("requested_status", req.RequestedStatus); err != nil {
+			return nil, err
+		}
+	}
 
 	if alloc, err := s.allocs.FindByID(ctx, req.ComputeAllocationID); err != nil {
 		return nil, fmt.Errorf("lookup compute allocation: %w", err)
@@ -137,6 +145,14 @@ func (s *Service) UpdateComputeAllocationChangeRequest(ctx context.Context, req 
 	}
 	if req.ChangeStatus == "" {
 		req.ChangeStatus = existing.ChangeStatus
+	}
+	if req.RequestedSUAmount < 0 {
+		return nil, fmt.Errorf("%w: requested_su_amount must be non-negative", ErrInvalidInput)
+	}
+	if req.RequestedStatus != "" {
+		if err := validateAllocationStatus("requested_status", req.RequestedStatus); err != nil {
+			return nil, err
+		}
 	}
 	if req.Timestamp.IsZero() {
 		req.Timestamp = existing.Timestamp

--- a/pkg/service/compute_allocation_diff.go
+++ b/pkg/service/compute_allocation_diff.go
@@ -43,6 +43,12 @@ func (s *Service) CreateComputeAllocationDiff(ctx context.Context, diff *models.
 	if diff.Status == "" {
 		return nil, fmt.Errorf("%w: status is required", ErrInvalidInput)
 	}
+	if diff.NewSUAmount < 0 {
+		return nil, fmt.Errorf("%w: new_su_amount must be non-negative", ErrInvalidInput)
+	}
+	if err := validateAllocationStatus("status", diff.Status); err != nil {
+		return nil, err
+	}
 
 	if alloc, err := s.allocs.FindByID(ctx, diff.ComputeAllocationID); err != nil {
 		return nil, fmt.Errorf("lookup compute allocation: %w", err)

--- a/pkg/service/compute_allocation_membership.go
+++ b/pkg/service/compute_allocation_membership.go
@@ -40,6 +40,9 @@ func (s *Service) CreateComputeAllocationMembership(ctx context.Context, m *mode
 	if m.UserID == "" {
 		return nil, fmt.Errorf("%w: user_id is required", ErrInvalidInput)
 	}
+	if err := validateRequiredTimeRange(m.StartTime, m.EndTime); err != nil {
+		return nil, err
+	}
 
 	if alloc, err := s.allocs.FindByID(ctx, m.ComputeAllocationID); err != nil {
 		return nil, fmt.Errorf("lookup compute allocation: %w", err)
@@ -63,6 +66,9 @@ func (s *Service) CreateComputeAllocationMembership(ctx context.Context, m *mode
 	}
 	if m.MembershipStatus == "" {
 		m.MembershipStatus = models.ACTIVE
+	}
+	if err := validateAllocationStatus("membership_status", m.MembershipStatus); err != nil {
+		return nil, err
 	}
 
 	if err := s.inTx(ctx, func(tx *sql.Tx) error {
@@ -143,6 +149,12 @@ func (s *Service) UpdateComputeAllocationMembership(ctx context.Context, m *mode
 	if m.MembershipStatus == "" {
 		m.MembershipStatus = existing.MembershipStatus
 	}
+	if err := validateRequiredTimeRange(m.StartTime, m.EndTime); err != nil {
+		return nil, err
+	}
+	if err := validateAllocationStatus("membership_status", m.MembershipStatus); err != nil {
+		return nil, err
+	}
 
 	if err := s.inTx(ctx, func(tx *sql.Tx) error {
 		return s.memberships.Update(ctx, tx, m)
@@ -162,6 +174,9 @@ func (s *Service) UpdateMembershipStatus(ctx context.Context, id string, status 
 	}
 	if status == "" {
 		return nil, fmt.Errorf("%w: membership_status is required", ErrInvalidInput)
+	}
+	if err := validateAllocationStatus("membership_status", status); err != nil {
+		return nil, err
 	}
 	existing, err := s.memberships.FindByID(ctx, id)
 	if err != nil {

--- a/pkg/service/compute_allocation_resource.go
+++ b/pkg/service/compute_allocation_resource.go
@@ -38,6 +38,9 @@ func (s *Service) CreateComputeAllocationResource(ctx context.Context, resource 
 	if resource.ResourceType == "" {
 		return nil, fmt.Errorf("%w: resource_type is required", ErrInvalidInput)
 	}
+	if resource.ResourceAmount < 0 {
+		return nil, fmt.Errorf("%w: resource_amount must be non-negative", ErrInvalidInput)
+	}
 	if resource.ID == "" {
 		resource.ID = newID()
 	}
@@ -78,6 +81,15 @@ func (s *Service) ListComputeAllocationResources(ctx context.Context) ([]models.
 func (s *Service) UpdateComputeAllocationResource(ctx context.Context, resource *models.ComputeAllocationResource) error {
 	if resource == nil || resource.ID == "" {
 		return fmt.Errorf("%w: compute allocation resource id is required", ErrInvalidInput)
+	}
+	if resource.Name == "" {
+		return fmt.Errorf("%w: resource name is required", ErrInvalidInput)
+	}
+	if resource.ResourceType == "" {
+		return fmt.Errorf("%w: resource_type is required", ErrInvalidInput)
+	}
+	if resource.ResourceAmount < 0 {
+		return fmt.Errorf("%w: resource_amount must be non-negative", ErrInvalidInput)
 	}
 	if err := s.inTx(ctx, func(tx *sql.Tx) error {
 		return s.resources.Update(ctx, tx, resource)

--- a/pkg/service/project.go
+++ b/pkg/service/project.go
@@ -59,6 +59,9 @@ func (s *Service) CreateProject(ctx context.Context, project *models.Project) (*
 	if project.Status == "" {
 		project.Status = models.ProjectActive
 	}
+	if err := validateProjectStatus(project.Status); err != nil {
+		return nil, err
+	}
 	if project.CreatedTime.IsZero() {
 		project.CreatedTime = nowUTC()
 	}
@@ -134,6 +137,9 @@ func (s *Service) UpdateProject(ctx context.Context, project *models.Project) er
 	if project.Status == "" {
 		project.Status = existing.Status
 	}
+	if err := validateProjectStatus(project.Status); err != nil {
+		return err
+	}
 	if project.CreatedTime.IsZero() {
 		project.CreatedTime = existing.CreatedTime
 	}
@@ -155,6 +161,9 @@ func (s *Service) UpdateProjectStatus(ctx context.Context, id string, status mod
 	}
 	if status == "" {
 		return nil, fmt.Errorf("%w: status is required", ErrInvalidInput)
+	}
+	if err := validateProjectStatus(status); err != nil {
+		return nil, err
 	}
 	existing, err := s.projs.FindByID(ctx, id)
 	if err != nil {

--- a/pkg/service/user.go
+++ b/pkg/service/user.go
@@ -57,6 +57,9 @@ func (s *Service) CreateUser(ctx context.Context, user *models.User) (*models.Us
 	if user.Status == "" {
 		user.Status = models.UserActive
 	}
+	if err := validateUserStatus(user.Status); err != nil {
+		return nil, err
+	}
 
 	if err := s.inTx(ctx, func(tx *sql.Tx) error {
 		return s.users.Create(ctx, tx, user)
@@ -160,6 +163,9 @@ func (s *Service) UpdateUser(ctx context.Context, user *models.User) error {
 	if user.Status == "" {
 		user.Status = existing.Status
 	}
+	if err := validateUserStatus(user.Status); err != nil {
+		return err
+	}
 
 	if err := s.inTx(ctx, func(tx *sql.Tx) error {
 		return s.users.Update(ctx, tx, user)
@@ -179,6 +185,9 @@ func (s *Service) UpdateUserStatus(ctx context.Context, id string, status models
 	}
 	if status == "" {
 		return nil, fmt.Errorf("%w: status is required", ErrInvalidInput)
+	}
+	if err := validateUserStatus(status); err != nil {
+		return nil, err
 	}
 	existing, err := s.users.FindByID(ctx, id)
 	if err != nil {

--- a/pkg/service/validation.go
+++ b/pkg/service/validation.go
@@ -1,0 +1,62 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package service
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/apache/airavata-custos/pkg/models"
+)
+
+func validateUserStatus(status models.UserStatus) error {
+	switch status {
+	case models.UserActive, models.UserInactive, models.UserSuspended, models.UserMerged:
+		return nil
+	default:
+		return fmt.Errorf("%w: unsupported user status %q", ErrInvalidInput, status)
+	}
+}
+
+func validateProjectStatus(status models.ProjectStatus) error {
+	switch status {
+	case models.ProjectActive, models.ProjectInactive, models.ProjectDeleted:
+		return nil
+	default:
+		return fmt.Errorf("%w: unsupported project status %q", ErrInvalidInput, status)
+	}
+}
+
+func validateAllocationStatus(field string, status models.AllocationStatus) error {
+	switch status {
+	case models.ACTIVE, models.INACTIVE, models.DELETED:
+		return nil
+	default:
+		return fmt.Errorf("%w: unsupported %s %q", ErrInvalidInput, field, status)
+	}
+}
+
+func validateRequiredTimeRange(start, end time.Time) error {
+	if start.IsZero() || end.IsZero() {
+		return fmt.Errorf("%w: start_time and end_time are required", ErrInvalidInput)
+	}
+	if !start.Before(end) {
+		return fmt.Errorf("%w: start_time must be before end_time", ErrInvalidInput)
+	}
+	return nil
+}

--- a/pkg/service/validation_test.go
+++ b/pkg/service/validation_test.go
@@ -1,0 +1,60 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package service
+
+import (
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/apache/airavata-custos/pkg/models"
+)
+
+func TestValidateStatusesRejectUnsupportedValues(t *testing.T) {
+	tests := []struct {
+		name string
+		err  error
+	}{
+		{name: "user", err: validateUserStatus(models.UserStatus("BANANA"))},
+		{name: "project", err: validateProjectStatus(models.ProjectStatus("BANANA"))},
+		{name: "allocation", err: validateAllocationStatus("status", models.AllocationStatus("BANANA"))},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if !errors.Is(tc.err, ErrInvalidInput) {
+				t.Fatalf("expected ErrInvalidInput, got %v", tc.err)
+			}
+		})
+	}
+}
+
+func TestValidateRequiredTimeRange(t *testing.T) {
+	start := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+	end := start.Add(time.Hour)
+
+	if err := validateRequiredTimeRange(start, end); err != nil {
+		t.Fatalf("expected valid range: %v", err)
+	}
+	if err := validateRequiredTimeRange(time.Time{}, end); !errors.Is(err, ErrInvalidInput) {
+		t.Fatalf("expected missing start_time to be invalid, got %v", err)
+	}
+	if err := validateRequiredTimeRange(end, start); !errors.Is(err, ErrInvalidInput) {
+		t.Fatalf("expected reversed range to be invalid, got %v", err)
+	}
+}


### PR DESCRIPTION
## Summary

- Require `application/json` content type and reject trailing JSON values in API request bodies.
- Map duplicate-key and invalid database constraint errors to client-facing `409`/`400` responses instead of generic `500` responses.
- Add service-layer validation for lifecycle statuses, required time ranges, and non-negative resource/SU amounts.
- Add focused tests and update API documentation to match enforced request-body behavior.

Fixes #478

## Tests

```bash
go build ./...
go vet ./...
go test ./...
```
