### PR TITLE
Identity response cleanup, a single REST call to get User info, and included Keycloak for development

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -36,6 +36,9 @@ OIDC_AUDIENCE=custos-api
 # Shared across connectors that need to know which cluster they belong to.
 CUSTOS_CLUSTER_ID=00000000-0000-0000-0000-000000000001
 
+# Grants super_admin to the user with this email on first boot. Idempotent.
+CUSTOS_BOOTSTRAP_ADMIN_EMAIL=admin@custos.local
+
 # --- AMIE connector (ACCESS-CI) ------------------------------------------
 
 AMIE_BASE_URL=http://localhost:8180

--- a/.env.example
+++ b/.env.example
@@ -25,9 +25,10 @@
 DATABASE_DSN=admin:admin@tcp(localhost:3306)/custos?parseTime=true&charset=utf8mb4&multiStatements=true
 
 # OIDC issuer + audience, into config/custos.yaml.
-# Server refuses to start without these once auth is wired.
-OIDC_ISSUER_URL=
-OIDC_AUDIENCE=
+# Server refuses to start without these.
+# Local Keycloak via dev-ops/compose; see dev-ops/compose/keycloak/import/custos-realm.json.
+OIDC_ISSUER_URL=http://localhost:8081/realms/custos
+OIDC_AUDIENCE=custos-api
 
 # --- Server: dev convenience ---------------------------------------------
 

--- a/api/core.openapi.yaml
+++ b/api/core.openapi.yaml
@@ -40,6 +40,15 @@ definitions:
     - ACTIVE
     - INACTIVE
     - DELETED
+  CallerProfileResponse:
+    properties:
+      privileges:
+        items:
+          $ref: '#/definitions/PrivilegeKey'
+        type: array
+      user:
+        $ref: '#/definitions/User'
+    type: object
   ComputeAllocation:
     properties:
       compute_cluster_id:
@@ -2563,6 +2572,27 @@ paths:
       summary: Get a compute cluster user by (cluster, user) pair
       tags:
       - Compute Cluster Users
+  /me:
+    get:
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/CallerProfileResponse'
+        "401":
+          description: Missing authenticated caller
+          schema:
+            properties:
+              error:
+                type: string
+            type: object
+      security:
+      - BearerAuth: []
+      summary: Get the caller's user record and effective privileges
+      tags:
+      - Caller
   /organizations:
     post:
       consumes:

--- a/dev-ops/compose/docker-compose.yml
+++ b/dev-ops/compose/docker-compose.yml
@@ -32,6 +32,43 @@ services:
       MAX_ALLOWED_PACKET: 1073741824
     volumes:
       - ./dbinit:/docker-entrypoint-initdb.d
+    healthcheck:
+      test: ["CMD", "healthcheck.sh", "--connect", "--innodb_initialized"]
+      interval: 5s
+      timeout: 5s
+      retries: 20
+      start_period: 30s
+
+  keycloak:
+    container_name: custos_keycloak
+    image: quay.io/keycloak/keycloak:26.0
+    restart: unless-stopped
+    command: ["start-dev", "--import-realm"]
+    environment:
+      KEYCLOAK_ADMIN: admin
+      KEYCLOAK_ADMIN_PASSWORD: admin
+      KC_DB: mariadb
+      KC_DB_URL: jdbc:mariadb://db:3306/keycloak
+      KC_DB_USERNAME: admin
+      KC_DB_PASSWORD: admin
+      KC_HOSTNAME_URL: http://localhost:8081
+      KC_HOSTNAME_STRICT: "false"
+      KC_HTTP_ENABLED: "true"
+      KC_HEALTH_ENABLED: "true"
+    ports:
+      - "8081:8080"
+      - "9001:9000"
+    volumes:
+      - ./keycloak/import:/opt/keycloak/data/import:ro
+    depends_on:
+      db:
+        condition: service_healthy
+    healthcheck:
+      test: ["CMD-SHELL", "exec 3<>/dev/tcp/localhost/9000 && printf 'GET /health/ready HTTP/1.0\\r\\n\\r\\n' >&3 && grep -q '\"status\": \"UP\"' <&3"]
+      interval: 10s
+      timeout: 5s
+      retries: 30
+      start_period: 60s
 
   adminer:
     image: adminer
@@ -44,7 +81,7 @@ services:
     container_name: prometheus
     restart: unless-stopped
     ports:
-      - "9090:9090"
+      - "19090:9090"
     volumes:
       - ./prometheus/prometheus.yml:/etc/prometheus/prometheus.yml
     extra_hosts:
@@ -55,7 +92,7 @@ services:
     container_name: grafana
     restart: unless-stopped
     ports:
-      - "3000:3000"
+      - "13000:3000"
     environment:
       GF_SECURITY_ADMIN_USER: admin
       GF_SECURITY_ADMIN_PASSWORD: admin

--- a/dev-ops/compose/keycloak/import/custos-realm.json
+++ b/dev-ops/compose/keycloak/import/custos-realm.json
@@ -1,0 +1,125 @@
+{
+  "_comment": "Use only for the local dev environment.",
+  "realm": "custos",
+  "enabled": true,
+  "sslRequired": "none",
+  "registrationAllowed": false,
+  "loginWithEmailAllowed": true,
+  "duplicateEmailsAllowed": false,
+  "accessTokenLifespan": 1800,
+  "clients": [
+    {
+      "clientId": "portal",
+      "enabled": true,
+      "protocol": "openid-connect",
+      "publicClient": false,
+      "secret": "portal-dev-secret",
+      "standardFlowEnabled": true,
+      "directAccessGrantsEnabled": false,
+      "serviceAccountsEnabled": false,
+      "redirectUris": [
+        "http://localhost:3000/api/auth/callback/oidc"
+      ],
+      "webOrigins": [
+        "http://localhost:3000"
+      ],
+      "attributes": {
+        "post.logout.redirect.uris": "http://localhost:3000/*"
+      },
+      "protocolMappers": [
+        {
+          "name": "custos-api-audience",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-audience-mapper",
+          "config": {
+            "included.custom.audience": "custos-api",
+            "id.token.claim": "false",
+            "access.token.claim": "true"
+          }
+        }
+      ]
+    }
+  ],
+  "users": [
+    {
+      "id": "a8f3c52d-7b1e-4d9a-8c3f-2e5b9d8a1c47",
+      "username": "admin",
+      "email": "admin@custos.local",
+      "emailVerified": true,
+      "enabled": true,
+      "firstName": "Admin",
+      "lastName": "Dev",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "admin",
+          "temporary": false
+        }
+      ]
+    },
+    {
+      "id": "b6e2f841-9c5d-4a3b-8f7e-1d6c3b9e8f25",
+      "username": "operator",
+      "email": "operator@custos.local",
+      "emailVerified": true,
+      "enabled": true,
+      "firstName": "Operator",
+      "lastName": "Dev",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "operator",
+          "temporary": false
+        }
+      ]
+    },
+    {
+      "id": "c4d9e3f7-8b2a-4f5d-9e1c-3a8b7d6e2f14",
+      "username": "auditor",
+      "email": "auditor@custos.local",
+      "emailVerified": true,
+      "enabled": true,
+      "firstName": "Auditor",
+      "lastName": "Dev",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "auditor",
+          "temporary": false
+        }
+      ]
+    },
+    {
+      "id": "e7b4c1a2-6d8f-4e9b-8a5c-7d3f9e2b1c08",
+      "username": "pi",
+      "email": "pi@custos.local",
+      "emailVerified": true,
+      "enabled": true,
+      "firstName": "PI",
+      "lastName": "Dev",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "pi",
+          "temporary": false
+        }
+      ]
+    },
+    {
+      "id": "d5a8b2e6-4f9c-4d1a-9b3e-9f2c6e1b8d54",
+      "username": "researcher",
+      "email": "researcher@custos.local",
+      "emailVerified": true,
+      "enabled": true,
+      "firstName": "Researcher",
+      "lastName": "Dev",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "researcher",
+          "temporary": false
+        }
+      ]
+    }
+  ]
+}

--- a/dev-ops/compose/seeds/dev_users_and_roles.sql
+++ b/dev-ops/compose/seeds/dev_users_and_roles.sql
@@ -15,7 +15,7 @@
 -- specific language governing permissions and limitations
 -- under the License.
 
--- Dev-only seed: inserts an org, four developer-facing users, and two
+-- Dev-only seed: inserts an org, five developer-facing users, and three
 -- non-system roles with sample privilege bundles. Apply after migrations
 -- have run; safe to re-apply (everything is idempotent).
 --
@@ -43,19 +43,25 @@ VALUES ('dev-org', 'DEV-ORG', 'Custos Dev Org');
 -- ---------------------------------------------------------------------------
 INSERT IGNORE INTO users (id, organization_id, first_name, last_name, middle_name, email, status)
 VALUES
+    -- site staff
     ('dev-admin',      'dev-org', 'Admin',      'Dev', '', 'admin@custos.local',      'ACTIVE'),
     ('dev-operator',   'dev-org', 'Operator',   'Dev', '', 'operator@custos.local',   'ACTIVE'),
     ('dev-auditor',    'dev-org', 'Auditor',    'Dev', '', 'auditor@custos.local',    'ACTIVE'),
+    -- researchers
+    ('dev-pi',         'dev-org', 'PI',         'Dev', '', 'pi@custos.local',         'ACTIVE'),
     ('dev-researcher', 'dev-org', 'Researcher', 'Dev', '', 'researcher@custos.local', 'ACTIVE');
 
 -- ---------------------------------------------------------------------------
 -- Roles (deterministic UUIDs so API examples stay stable across re-applies)
 -- ---------------------------------------------------------------------------
--- operator: AMIE + HPC read/write. Day-to-day operations of HPC + AMIE flows.
+-- operator: AMIE + cluster read/write. Day-to-day operations of cluster + AMIE flows.
+-- pi:       Manages own projects/allocations + reads AMIE status.
+-- auditor:  Read-only across AMIE and cluster surfaces.
 INSERT IGNORE INTO roles (id, name, description, is_system)
 VALUES
-    ('11111111-1111-1111-1111-111111111111', 'operator', 'Day-to-day AMIE and HPC operations (read + write)', 0),
-    ('22222222-2222-2222-2222-222222222222', 'auditor', 'Read-only access across AMIE and HPC surfaces', 0);
+    ('11111111-1111-1111-1111-111111111111', 'operator', 'Day-to-day AMIE and cluster operations (read + write)', 0),
+    ('22222222-2222-2222-2222-222222222222', 'auditor',  'Read-only access across AMIE and cluster surfaces', 0),
+    ('33333333-3333-3333-3333-333333333333', 'pi',       'Principal Investigator - manages own projects and allocations', 0);
 
 -- operator privileges
 INSERT IGNORE INTO role_privileges (role_id, privilege) VALUES
@@ -75,13 +81,38 @@ INSERT IGNORE INTO role_privileges (role_id, privilege) VALUES
     ('22222222-2222-2222-2222-222222222222', 'amie:unmapped:read'),
     ('22222222-2222-2222-2222-222222222222', 'core:clusters:read');
 
+-- pi privileges
+INSERT IGNORE INTO role_privileges (role_id, privilege) VALUES
+    ('33333333-3333-3333-3333-333333333333', 'amie:packets:read'),
+    ('33333333-3333-3333-3333-333333333333', 'amie:replies:read'),
+    ('33333333-3333-3333-3333-333333333333', 'core:clusters:read'),
+    ('33333333-3333-3333-3333-333333333333', 'core:clusters:write');
+
 -- ---------------------------------------------------------------------------
 -- Role assignments
 -- ---------------------------------------------------------------------------
 INSERT IGNORE INTO user_roles (user_id, role_id, granted_by, reason)
 VALUES
+    -- site staff
     ('dev-operator', '11111111-1111-1111-1111-111111111111', 'dev-admin', 'dev seed'),
-    ('dev-auditor',  '22222222-2222-2222-2222-222222222222', 'dev-admin', 'dev seed');
+    ('dev-auditor',  '22222222-2222-2222-2222-222222222222', 'dev-admin', 'dev seed'),
+    -- researchers
+    ('dev-pi',       '33333333-3333-3333-3333-333333333333', 'dev-admin', 'dev seed');
 
 -- dev-researcher holds no roles - used to exercise 403 paths from a
 -- low-privilege caller.
+
+-- ---------------------------------------------------------------------------
+-- OIDC identity link rows - oidc_sub UUIDs match the user `id` field in
+-- dev-ops/compose/keycloak/import/custos-realm.json so a Keycloak sign-in
+-- resolves to the right backend user via identity_resolver.
+-- ---------------------------------------------------------------------------
+INSERT IGNORE INTO user_identities (id, user_id, source, external_id, email, oidc_sub)
+VALUES
+    -- site staff
+    ('ui-dev-admin',      'dev-admin',      'keycloak', 'a8f3c52d-7b1e-4d9a-8c3f-2e5b9d8a1c47', 'admin@custos.local',      'a8f3c52d-7b1e-4d9a-8c3f-2e5b9d8a1c47'),
+    ('ui-dev-operator',   'dev-operator',   'keycloak', 'b6e2f841-9c5d-4a3b-8f7e-1d6c3b9e8f25', 'operator@custos.local',   'b6e2f841-9c5d-4a3b-8f7e-1d6c3b9e8f25'),
+    ('ui-dev-auditor',    'dev-auditor',    'keycloak', 'c4d9e3f7-8b2a-4f5d-9e1c-3a8b7d6e2f14', 'auditor@custos.local',    'c4d9e3f7-8b2a-4f5d-9e1c-3a8b7d6e2f14'),
+    -- researchers
+    ('ui-dev-pi',         'dev-pi',         'keycloak', 'e7b4c1a2-6d8f-4e9b-8a5c-7d3f9e2b1c08', 'pi@custos.local',         'e7b4c1a2-6d8f-4e9b-8a5c-7d3f9e2b1c08'),
+    ('ui-dev-researcher', 'dev-researcher', 'keycloak', 'd5a8b2e6-4f9c-4d1a-9b3e-9f2c6e1b8d54', 'researcher@custos.local', 'd5a8b2e6-4f9c-4d1a-9b3e-9f2c6e1b8d54');

--- a/internal/db/migrations/000014_project_memberships.up.sql
+++ b/internal/db/migrations/000014_project_memberships.up.sql
@@ -19,8 +19,8 @@
 -- status is derived from compute_allocation_memberships, so it is not stored
 -- here. One row per (project, user).
 CREATE TABLE project_memberships (
-    project_id CHAR(36) NOT NULL,
-    user_id    CHAR(36) NOT NULL,
+    project_id VARCHAR(255) NOT NULL,
+    user_id    VARCHAR(255) NOT NULL,
     role       VARCHAR(32) NOT NULL,
     added_time DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
     PRIMARY KEY (project_id, user_id),

--- a/internal/server/privilege.go
+++ b/internal/server/privilege.go
@@ -45,6 +45,37 @@ func (s *Server) getCallerPrivileges(w http.ResponseWriter, r *http.Request) {
 	common.WriteJSON(w, http.StatusOK, map[string]any{"privileges": keys})
 }
 
+// CallerProfileResponse bundles the caller's user row with the effective
+// privilege set.
+type CallerProfileResponse struct {
+	User       *models.User          `json:"user"`
+	Privileges []models.PrivilegeKey `json:"privileges"`
+}
+
+// @Summary	Get the caller's user record and effective privileges
+// @Tags	Caller
+// @Security	BearerAuth
+// @Produce	json
+// @Success	200	{object}	CallerProfileResponse
+// @Failure	401	{object}	object{error=string}	"Missing authenticated caller"
+// @Router	/me [get]
+func (s *Server) getCallerProfile(w http.ResponseWriter, r *http.Request) {
+	caller := requireCaller(w, r)
+	if caller == nil {
+		return
+	}
+	user, err := s.svc.GetUser(r.Context(), caller.UserID)
+	if err != nil {
+		common.WriteServiceError(w, err)
+		return
+	}
+	keys := identity.PrivilegesFromContext(r.Context())
+	if keys == nil {
+		keys = []models.PrivilegeKey{}
+	}
+	common.WriteJSON(w, http.StatusOK, CallerProfileResponse{User: user, Privileges: keys})
+}
+
 // @Summary	List the declared privilege catalog
 // @Tags	Privileges
 // @Security	BearerAuth

--- a/internal/server/privilege_integration_test.go
+++ b/internal/server/privilege_integration_test.go
@@ -83,6 +83,37 @@ func TestGetCallerPrivileges_WithGrants(t *testing.T) {
 	}
 }
 
+func TestGetCallerProfile_NoCaller_401(t *testing.T) {
+	_, _, srv := setupTestStack(t)
+	rr := httptest.NewRecorder()
+	srv.ServeHTTP(rr, httptest.NewRequest(http.MethodGet, "/me", nil))
+	if rr.Code != http.StatusUnauthorized {
+		t.Errorf("status: got %d, want 401", rr.Code)
+	}
+}
+
+func TestGetCallerProfile_ReturnsUserAndPrivileges(t *testing.T) {
+	database, _, srv := setupTestStack(t)
+	user := seedUser(t, database, "user@example.edu")
+	rr := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/me", nil)
+	req = withTestCaller(req, user, models.PrivilegesGrant)
+	srv.ServeHTTP(rr, req)
+	if rr.Code != http.StatusOK {
+		t.Fatalf("status: got %d, want 200; body=%s", rr.Code, rr.Body.String())
+	}
+	var body CallerProfileResponse
+	if err := json.NewDecoder(rr.Body).Decode(&body); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if body.User == nil || body.User.ID != user {
+		t.Errorf("user.id: got %+v, want %s", body.User, user)
+	}
+	if len(body.Privileges) != 1 || body.Privileges[0] != models.PrivilegesGrant {
+		t.Errorf("privileges: got %v, want [%s]", body.Privileges, models.PrivilegesGrant)
+	}
+}
+
 func TestRequirePrivilege_NoGrants_403(t *testing.T) {
 	database, _, srv := setupTestStack(t)
 	user := seedUser(t, database, "user@example.edu")

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -164,8 +164,9 @@ func (s *Server) routes() {
 	s.router.RequireAuth("GET /user-identities/oidc-subjects/{oidcSub}", s.getUserIdentityByOIDCSub)
 	s.router.RequireAuth("GET /users/{id}/user-identities", s.listUserIdentitiesForUser)
 
-	// Any authenticated caller may read their own effective privilege set with no privilege check.
+	// Any authenticated caller may read their own profile and effective privilege set with no privilege check.
 	s.router.RequireAuth("GET /user/privileges", s.getCallerPrivileges)
+	s.router.RequireAuth("GET /me", s.getCallerProfile)
 	s.router.RequirePrivilege("GET /privileges/catalog", models.PrivilegesGrant, s.getPrivilegeCatalog)
 	s.router.RequirePrivilege("GET /users/{id}/privileges", models.PrivilegesGrant, s.listUserPrivileges)
 	s.router.RequirePrivilege("GET /privileges/{key}/holders", models.PrivilegesGrant, s.listPrivilegeHolders)

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -90,8 +90,8 @@ func (s *Server) routes() {
 	s.router.RequireAuth("GET /compute-cluster-users/{id}", s.getComputeClusterUser)
 	s.router.RequireAuth("PUT /compute-cluster-users/{id}", s.updateComputeClusterUser)
 	s.router.RequireAuth("DELETE /compute-cluster-users/{id}", s.deleteComputeClusterUser)
-	s.router.RequireAuth("GET /compute-clusters/{id}/users", s.listComputeClusterUsersByCluster)
-	s.router.RequireAuth("GET /compute-clusters/{id}/users/{userId}", s.getComputeClusterUserByPair)
+	s.router.RequirePrivilege("GET /compute-clusters/{id}/users", models.ClustersRead, s.listComputeClusterUsersByCluster)
+	s.router.RequirePrivilege("GET /compute-clusters/{id}/users/{userId}", models.ClustersRead, s.getComputeClusterUserByPair)
 	s.router.RequireAuth("GET /users/{id}/compute-cluster-users", s.listComputeClusterUsersByUser)
 
 	s.router.RequireAuth("GET /compute-allocations", s.listComputeAllocations)

--- a/pkg/identity/middleware.go
+++ b/pkg/identity/middleware.go
@@ -41,21 +41,21 @@ func Middleware(verifier *JWTVerifier, resolver UserResolver, publicPaths []stri
 		}
 		rawToken, ok := bearer(req.Header.Get("Authorization"))
 		if !ok {
-			writeJSONError(w, http.StatusUnauthorized, "missing_bearer")
+			writeJSONError(w, http.StatusUnauthorized, "missing_bearer", "Missing bearer token")
 			return
 		}
 		claims, err := verifier.Verify(req.Context(), rawToken)
 		if err != nil {
-			writeJSONError(w, http.StatusUnauthorized, "invalid_token")
+			writeJSONError(w, http.StatusUnauthorized, "invalid_token", "Invalid or expired bearer token")
 			return
 		}
 		caller, privileges, err := resolver.ResolveCaller(req.Context(), claims.Sub)
 		if errors.Is(err, ErrNotLinked) {
-			writeJSONError(w, http.StatusUnauthorized, "identity_not_linked")
+			writeJSONError(w, http.StatusUnauthorized, "identity_not_linked", "OIDC identity is not linked to a portal user")
 			return
 		}
 		if err != nil {
-			writeJSONError(w, http.StatusServiceUnavailable, "auth lookup failed")
+			writeJSONError(w, http.StatusServiceUnavailable, "auth_lookup_failed", "Identity resolution failed")
 			return
 		}
 		ctx := WithCaller(req.Context(), caller)
@@ -79,7 +79,7 @@ func NewRouter(mux *http.ServeMux) *Router { return &Router{mux: mux} }
 func (r *Router) RequirePrivilege(pattern string, privilege models.PrivilegeKey, handler http.HandlerFunc) {
 	r.mux.HandleFunc(pattern, func(w http.ResponseWriter, req *http.Request) {
 		if !HasPrivilege(req.Context(), privilege) {
-			writeJSONError(w, http.StatusForbidden, "insufficient privilege")
+			writeJSONError(w, http.StatusForbidden, "insufficient_privilege", "Caller lacks required privilege")
 			return
 		}
 		handler(w, req)
@@ -124,10 +124,11 @@ func methodPath(pattern string) string {
 	return pattern
 }
 
-// writeJSONError emits a {"error":"..."} body to keep pkg/identity free of
-// any pkg/common dependency.
-func writeJSONError(w http.ResponseWriter, status int, msg string) {
+// TODO: use pkg/common.WriteJSON once its import cycle is broken.
+//
+//	Cycle: pkg/identity → pkg/common → pkg/service → pkg/identity.
+func writeJSONError(w http.ResponseWriter, status int, code, message string) {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(status)
-	_ = json.NewEncoder(w).Encode(map[string]string{"error": msg})
+	_ = json.NewEncoder(w).Encode(map[string]string{"code": code, "message": message})
 }


### PR DESCRIPTION
- Updated the shape of identity-related error responses so the portal can render consistent messages.
- Tightens the permissions needed on the cluster user-lookup routes.
- Included a new REST endpoint `/me` to get the UserProfile + effective privileges set.
- Update the `project_id` and `user_id` type to VARCHAR in `project_memebership` table.
- Regenerated the swag api.
- Included keycloak configurations --> docker compose and realm json. (only for the development so the developers can develop without bypassing the auth)