### PR TITLE
Integrate SSH certificate signer into web dashboard

### DIFF
--- a/extensions/SSH-Certificate-Signer/internal/handler/revoke.go
+++ b/extensions/SSH-Certificate-Signer/internal/handler/revoke.go
@@ -17,12 +17,14 @@ package handler
 
 import (
 	"encoding/json"
+	"errors"
 	"log/slog"
 	"net/http"
 
 	"github.com/apache/airavata-custos/signer/internal/audit"
 	"github.com/apache/airavata-custos/signer/internal/httputil"
 	"github.com/apache/airavata-custos/signer/internal/metrics"
+	"github.com/apache/airavata-custos/signer/internal/store"
 )
 
 type RevokeRequest struct {
@@ -40,12 +42,14 @@ type RevokeResponse struct {
 
 type RevokeHandler struct {
 	auditLogger *audit.Logger
+	db          *store.DB
 	logger      *slog.Logger
 }
 
-func NewRevokeHandler(auditLogger *audit.Logger, logger *slog.Logger) *RevokeHandler {
+func NewRevokeHandler(auditLogger *audit.Logger, db *store.DB, logger *slog.Logger) *RevokeHandler {
 	return &RevokeHandler{
 		auditLogger: auditLogger,
+		db:          db,
 		logger:      logger,
 	}
 }
@@ -79,6 +83,28 @@ func (h *RevokeHandler) Handle(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	revokedBy := tenantID + ":" + clientID
+
+	// When a serial is supplied, use the shared store method so this route gets
+	// the same existence check, transactional insert, and idempotency as the
+	// portal route. Unknown serials fall back to the legacy audit insert to
+	// preserve backward compatibility for automated clients.
+	if h.db != nil && req.SerialNumber != nil && *req.SerialNumber > 0 {
+		if _, err := h.db.RevokeCertificateBySerial(r.Context(), *req.SerialNumber, req.Reason, revokedBy); err != nil {
+			if !errors.Is(err, store.ErrCertificateNotFound) {
+				metrics.RevokeRequestsTotal.WithLabelValues(tenantID, "error").Inc()
+				h.logger.Error("failed to revoke certificate", "error", err)
+				writeError(w, http.StatusInternalServerError, "internal_error", "Failed to record revocation")
+				return
+			}
+			// Not found: fall through to the legacy audit insert below.
+		} else {
+			metrics.RevokeRequestsTotal.WithLabelValues(tenantID, "success").Inc()
+			h.writeSuccess(w)
+			return
+		}
+	}
+
 	entry := &audit.RevocationEntry{
 		TenantID:      tenantID,
 		ClientID:      clientID,
@@ -86,7 +112,7 @@ func (h *RevokeHandler) Handle(w http.ResponseWriter, r *http.Request) {
 		KeyID:         req.KeyID,
 		CAFingerprint: req.CAFingerprint,
 		Reason:        req.Reason,
-		RevokedBy:     tenantID + ":" + clientID,
+		RevokedBy:     revokedBy,
 	}
 
 	if err := h.auditLogger.LogRevocation(r.Context(), entry); err != nil {
@@ -97,13 +123,15 @@ func (h *RevokeHandler) Handle(w http.ResponseWriter, r *http.Request) {
 	}
 
 	metrics.RevokeRequestsTotal.WithLabelValues(tenantID, "success").Inc()
+	h.writeSuccess(w)
+}
 
+func (h *RevokeHandler) writeSuccess(w http.ResponseWriter) {
 	resp := RevokeResponse{
 		Success:      true,
 		Message:      "Certificate(s) revoked successfully",
 		RevokedCount: 1,
 	}
-
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(http.StatusOK)
 	json.NewEncoder(w).Encode(resp)

--- a/extensions/SSH-Certificate-Signer/internal/store/revocation.go
+++ b/extensions/SSH-Certificate-Signer/internal/store/revocation.go
@@ -18,8 +18,14 @@ package store
 import (
 	"context"
 	"database/sql"
+	"errors"
 	"fmt"
+	"time"
 )
+
+// ErrCertificateNotFound is returned when no certificate matches the serial for
+// the requesting owner (either it does not exist or belongs to another user).
+var ErrCertificateNotFound = errors.New("certificate not found")
 
 type RevocationEvent struct {
 	TenantID      string
@@ -29,6 +35,15 @@ type RevocationEvent struct {
 	CAFingerprint *string
 	Reason        string
 	RevokedBy     string
+}
+
+// RevokedCertificate is the outcome of a revoke request. AlreadyRevoked is true
+// when a prior revocation existed, in which case RevokedAt/Reason echo that row.
+type RevokedCertificate struct {
+	SerialNumber   int64
+	Reason         string
+	RevokedAt      time.Time
+	AlreadyRevoked bool
 }
 
 func (d *DB) InsertRevocationEvent(ctx context.Context, ev *RevocationEvent) error {
@@ -55,4 +70,89 @@ func (d *DB) InsertRevocationEvent(ctx context.Context, ev *RevocationEvent) err
 		return fmt.Errorf("inserting revocation event: %w", err)
 	}
 	return nil
+}
+
+// RevokeCertificateBySerial revokes the certificate identified by serial. It does
+// NOT scope by owner — authorization is enforced by the caller (an administrator
+// holding signer:certificates:write, or a trusted machine client). It is
+// idempotent: a repeat revoke returns the existing revocation (AlreadyRevoked=true)
+// without inserting a duplicate event. The revocation event inherits the
+// certificate's tenant/client.
+func (d *DB) RevokeCertificateBySerial(
+	ctx context.Context,
+	serialNumber int64,
+	reason string,
+	revokedBy string,
+) (*RevokedCertificate, error) {
+	tx, err := d.BeginTx(ctx, nil)
+	if err != nil {
+		return nil, fmt.Errorf("beginning transaction: %w", err)
+	}
+	defer func() { _ = tx.Rollback() }()
+
+	// Existence check; the revocation event inherits the certificate's tenant/client.
+	var tenantID, clientID, keyID, caFingerprint string
+	err = tx.QueryRowContext(ctx,
+		`SELECT tenant_id, client_id, key_id, ca_fingerprint
+		 FROM certificate_issuance_logs
+		 WHERE serial_number = ?
+		 LIMIT 1`,
+		serialNumber,
+	).Scan(&tenantID, &clientID, &keyID, &caFingerprint)
+	if err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return nil, ErrCertificateNotFound
+		}
+		return nil, fmt.Errorf("looking up certificate: %w", err)
+	}
+
+	// Idempotency: if a revocation already exists for this serial, return it.
+	var existingRevokedAt time.Time
+	var existingReason string
+	err = tx.QueryRowContext(ctx,
+		`SELECT revoked_at, reason
+		 FROM revocation_events
+		 WHERE serial_number = ?
+		 ORDER BY revoked_at DESC, id DESC
+		 LIMIT 1`,
+		serialNumber,
+	).Scan(&existingRevokedAt, &existingReason)
+	switch {
+	case err == nil:
+		if commitErr := tx.Commit(); commitErr != nil {
+			return nil, fmt.Errorf("committing transaction: %w", commitErr)
+		}
+		return &RevokedCertificate{
+			SerialNumber:   serialNumber,
+			Reason:         existingReason,
+			RevokedAt:      existingRevokedAt,
+			AlreadyRevoked: true,
+		}, nil
+	case errors.Is(err, sql.ErrNoRows):
+		// fall through to insert
+	default:
+		return nil, fmt.Errorf("checking existing revocation: %w", err)
+	}
+
+	revokedAt := time.Now().UTC()
+	_, err = tx.ExecContext(ctx,
+		`INSERT INTO revocation_events
+		 (tenant_id, client_id, serial_number, key_id, ca_fingerprint, revoked_at, reason, revoked_by)
+		 VALUES (?, ?, ?, ?, ?, ?, ?, ?)`,
+		tenantID, clientID, serialNumber, keyID, caFingerprint, revokedAt, reason, revokedBy,
+	)
+	if err != nil {
+		return nil, fmt.Errorf("inserting revocation event: %w", err)
+	}
+
+	if err := tx.Commit(); err != nil {
+		return nil, fmt.Errorf("committing transaction: %w", err)
+	}
+
+	return &RevokedCertificate{
+		SerialNumber:   serialNumber,
+		Reason:         reason,
+		RevokedAt:      revokedAt,
+		AlreadyRevoked: false,
+	}, nil
 }

--- a/extensions/SSH-Certificate-Signer/main.go
+++ b/extensions/SSH-Certificate-Signer/main.go
@@ -168,7 +168,7 @@ func runServer(cfg *config.Config, logger *slog.Logger, autoMigrate bool) {
 		"cache_ttl_seconds", cfg.Signer.Validation.CacheTTLSeconds)
 
 	signHandler := handler.NewSignHandler(oidcValidator, policyEnforcer, principalValidator, vaultClient, auditLogger, logger)
-	revokeHandler := handler.NewRevokeHandler(auditLogger, logger)
+	revokeHandler := handler.NewRevokeHandler(auditLogger, db, logger)
 	jwksHandler := handler.NewJWKSHandler(vaultClient, logger)
 	caPublicKeyHandler := handler.NewCAPublicKeyHandler(vaultClient, logger)
 	healthHandler := handler.NewHealthHandler(db, vaultClient)

--- a/pkg/models/privilege.go
+++ b/pkg/models/privilege.go
@@ -40,6 +40,10 @@ const (
 	TracesRead         PrivilegeKey = "core:traces:read"
 	PrivilegesGrant    PrivilegeKey = "core:privileges:grant"
 	RolesManage        PrivilegeKey = "core:roles:manage"
+	// SSH Certificate Signer capabilities. Read gates viewing the certificates
+	// dashboard; write authorizes administrative certificate revocation.
+	SignerCertificatesRead  PrivilegeKey = "signer:certificates:read"
+	SignerCertificatesWrite PrivilegeKey = "signer:certificates:write"
 )
 
 var (
@@ -62,6 +66,8 @@ func init() {
 		TracesRead,
 		PrivilegesGrant,
 		RolesManage,
+		SignerCertificatesRead,
+		SignerCertificatesWrite,
 	)
 }
 

--- a/web/.env.example
+++ b/web/.env.example
@@ -26,6 +26,9 @@ NEXTAUTH_URL=http://localhost:3000
 # Custos backend
 CUSTOS_CORE_API_BASE_URL=http://localhost:8080
 
+# SSH Certificate Signer (separate service; proxy routes /signer/* here)
+CUSTOS_SIGNER_API_BASE_URL=http://localhost:8084
+
 # OIDC (required).
 #
 # Defaults point at the bundled Keycloak from dev-ops/compose; users seeded

--- a/web/src/app/(portal)/signer/PermissionGate.tsx
+++ b/web/src/app/(portal)/signer/PermissionGate.tsx
@@ -1,0 +1,30 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+"use client";
+
+import type { ReactNode } from "react";
+import { useAbility } from "@/shared/casl/AbilityProvider";
+import { ErrorState } from "@/shared/ui/ErrorState";
+
+export function SignerPermissionGate({ children }: { children: ReactNode }) {
+  const ability = useAbility();
+  if (ability.cannot("read", "Signer")) {
+    return <ErrorState message="Not permitted." />;
+  }
+  return <>{children}</>;
+}

--- a/web/src/app/(portal)/signer/certificates/CertificateListContainer.tsx
+++ b/web/src/app/(portal)/signer/certificates/CertificateListContainer.tsx
@@ -1,0 +1,75 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+"use client";
+
+import * as React from "react";
+import {
+  replaceShallowSearchParams,
+  useShallowSearchParams,
+} from "@/shared/hooks/useShallowSearchParams";
+import { CertificateList } from "@/features/core/signer/components/CertificateList";
+import { useCertificates } from "@/features/core/signer/queries";
+import type { CertificateStatus } from "@/features/core/signer/status";
+
+function statusFilterFromUrl(raw: string | null): CertificateStatus | "all" {
+  if (raw === "active" || raw === "expired" || raw === "revoked") return raw;
+  return "all";
+}
+
+export function CertificateListContainer() {
+  const searchParams = useShallowSearchParams();
+  const [page, setPage] = React.useState(1);
+  const [pageSize, setPageSize] = React.useState(20);
+
+  const search = searchParams.get("q") ?? "";
+  const statusFilter = statusFilterFromUrl(searchParams.get("status"));
+
+  const updateParam = React.useCallback(
+    (key: string, value: string | null) => {
+      const params = new URLSearchParams(searchParams.toString());
+      if (!value) params.delete(key);
+      else params.set(key, value);
+      replaceShallowSearchParams(params);
+    },
+    [searchParams],
+  );
+
+  const query = useCertificates({ limit: pageSize, offset: (page - 1) * pageSize });
+  const rows = query.data?.certificates ?? [];
+  const total = query.data?.total ?? 0;
+
+  return (
+    <CertificateList
+      rows={rows}
+      isLoading={query.isLoading}
+      error={(query.error as Error | null) ?? null}
+      onRetry={() => query.refetch()}
+      search={search}
+      onSearchChange={(next) => updateParam("q", next)}
+      statusFilter={statusFilter}
+      onStatusFilterChange={(next) => updateParam("status", next === "all" ? null : next)}
+      pagination={{
+        page,
+        pageSize,
+        total,
+        onPageChange: setPage,
+        onPageSizeChange: setPageSize,
+      }}
+    />
+  );
+}

--- a/web/src/app/(portal)/signer/certificates/[serial]/page.tsx
+++ b/web/src/app/(portal)/signer/certificates/[serial]/page.tsx
@@ -1,0 +1,25 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import { CertificateDetail } from "@/features/core/signer/components/CertificateDetail";
+
+export default async function CertificateDetailPage(props: {
+  params: Promise<{ serial: string }>;
+}) {
+  const { serial } = await props.params;
+  return <CertificateDetail serial={serial} />;
+}

--- a/web/src/app/(portal)/signer/certificates/page.tsx
+++ b/web/src/app/(portal)/signer/certificates/page.tsx
@@ -1,0 +1,22 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import { CertificateListContainer } from "./CertificateListContainer";
+
+export default function CertificatesPage() {
+  return <CertificateListContainer />;
+}

--- a/web/src/app/(portal)/signer/layout.tsx
+++ b/web/src/app/(portal)/signer/layout.tsx
@@ -1,0 +1,23 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import type { ReactNode } from "react";
+import { SignerPermissionGate } from "./PermissionGate";
+
+export default function SignerLayout({ children }: { children: ReactNode }) {
+  return <SignerPermissionGate>{children}</SignerPermissionGate>;
+}

--- a/web/src/app/api/v1/[...path]/route.ts
+++ b/web/src/app/api/v1/[...path]/route.ts
@@ -25,7 +25,14 @@ type Context = { params: Promise<{ path: string[] }> };
 
 async function proxy(request: NextRequest, ctx: Context) {
   const { path } = await ctx.params;
-  const upstreamUrl = new URL(`/${path.join("/")}`, serverEnv.CUSTOS_CORE_API_BASE_URL);
+  // The signer is a separate service rooted at /api/v1; strip the "signer"
+  // routing segment and forward the rest with the user's Bearer.
+  const isSigner = path[0] === "signer";
+  const baseUrl = isSigner
+    ? serverEnv.CUSTOS_SIGNER_API_BASE_URL
+    : serverEnv.CUSTOS_CORE_API_BASE_URL;
+  const upstreamPath = isSigner ? `/api/v1/${path.slice(1).join("/")}` : `/${path.join("/")}`;
+  const upstreamUrl = new URL(upstreamPath, baseUrl);
   upstreamUrl.search = request.nextUrl.search;
 
   const session = await getPortalSession();

--- a/web/src/features/core/signer/__fixtures__/certificates.json
+++ b/web/src/features/core/signer/__fixtures__/certificates.json
@@ -1,0 +1,46 @@
+[
+  {
+    "serial_number": 42,
+    "key_id": "dev-admin@login.cluster.example.org-1700000000",
+    "principal": "dev-admin",
+    "public_key_fingerprint": "SHA256:7d8f2a1bUserKeyFingerprintActiveExample0001",
+    "ca_fingerprint": "SHA256:caFingerprintExample00000000000000000000001",
+    "valid_after": 1700000000,
+    "valid_before": 4102444800,
+    "issued_at": 1700000000,
+    "source_ip": "203.0.113.42",
+    "granted_extensions": ["permit-pty", "permit-user-rc"],
+    "force_command": null,
+    "revoked": false
+  },
+  {
+    "serial_number": 43,
+    "key_id": "dev-admin@login.cluster.example.org-1576800000",
+    "principal": "dev-admin",
+    "public_key_fingerprint": "SHA256:9a1c3e5bUserKeyFingerprintExpiredExample002",
+    "ca_fingerprint": "SHA256:caFingerprintExample00000000000000000000001",
+    "valid_after": 1576800000,
+    "valid_before": 1577836800,
+    "issued_at": 1576800000,
+    "source_ip": "203.0.113.43",
+    "granted_extensions": ["permit-pty"],
+    "force_command": null,
+    "revoked": false
+  },
+  {
+    "serial_number": 44,
+    "key_id": "dev-admin@login.cluster.example.org-1690000000",
+    "principal": "dev-admin",
+    "public_key_fingerprint": "SHA256:4b6d8f0aUserKeyFingerprintRevokedExample003",
+    "ca_fingerprint": "SHA256:caFingerprintExample00000000000000000000001",
+    "valid_after": 1690000000,
+    "valid_before": 4102444800,
+    "issued_at": 1690000000,
+    "source_ip": "203.0.113.44",
+    "granted_extensions": ["permit-pty"],
+    "force_command": null,
+    "revoked": true,
+    "revoked_at": 1690500000,
+    "revocation_reason": "Key compromised"
+  }
+]

--- a/web/src/features/core/signer/__tests__/CertificateDetail.test.tsx
+++ b/web/src/features/core/signer/__tests__/CertificateDetail.test.tsx
@@ -1,0 +1,76 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import { render, screen } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { Certificate } from "../schemas";
+
+// Presentation gating only — backend enforces the real authorization.
+const state = vi.hoisted(() => ({
+  canManage: true,
+  cert: {
+    serial_number: 42,
+    key_id: "k",
+    principal: "someone-else",
+    public_key_fingerprint: "SHA256:pk",
+    ca_fingerprint: "SHA256:ca",
+    valid_after: 1_700_000_000,
+    valid_before: 4_102_444_800,
+    issued_at: 1_700_000_000,
+    revoked: false,
+  } as Certificate,
+}));
+
+vi.mock("@/shared/casl/AbilityProvider", () => ({
+  useAbility: () => ({
+    can: (action: string, subject: string) =>
+      action === "manage" && subject === "Signer" ? state.canManage : true,
+  }),
+}));
+
+vi.mock("../queries", () => ({
+  useCertificate: () => ({ data: state.cert, isLoading: false, error: null, refetch: vi.fn() }),
+  useRevokeCertificate: () => ({ mutate: vi.fn(), isPending: false }),
+}));
+
+import { CertificateDetail } from "../components/CertificateDetail";
+
+beforeEach(() => {
+  state.canManage = true;
+  state.cert = { ...state.cert, revoked: false };
+});
+
+describe("<CertificateDetail /> revoke gating", () => {
+  it("shows the Revoke button for an admin with the signer write privilege", () => {
+    state.canManage = true;
+    render(<CertificateDetail serial="42" />);
+    expect(screen.getByRole("button", { name: /^Revoke$/ })).toBeInTheDocument();
+  });
+
+  it("hides the Revoke button for a user without the privilege (ownership is irrelevant)", () => {
+    state.canManage = false;
+    render(<CertificateDetail serial="42" />);
+    expect(screen.queryByRole("button", { name: /^Revoke$/ })).not.toBeInTheDocument();
+  });
+
+  it("hides the Revoke button when the certificate is already revoked", () => {
+    state.canManage = true;
+    state.cert = { ...state.cert, revoked: true, revoked_at: 1_700_500_000, revocation_reason: "old" };
+    render(<CertificateDetail serial="42" />);
+    expect(screen.queryByRole("button", { name: /^Revoke$/ })).not.toBeInTheDocument();
+  });
+});

--- a/web/src/features/core/signer/__tests__/CertificateList.test.tsx
+++ b/web/src/features/core/signer/__tests__/CertificateList.test.tsx
@@ -1,0 +1,83 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import { CertificateList } from "../components/CertificateList";
+import type { Certificate } from "../schemas";
+
+const active: Certificate = {
+  serial_number: 42,
+  key_id: "k-active",
+  principal: "dev-admin",
+  public_key_fingerprint: "SHA256:pk",
+  ca_fingerprint: "SHA256:ca",
+  valid_after: 1_700_000_000,
+  valid_before: 4_102_444_800,
+  issued_at: 1_700_000_000,
+  revoked: false,
+};
+
+const revoked: Certificate = {
+  ...active,
+  serial_number: 44,
+  key_id: "k-revoked",
+  revoked: true,
+  revoked_at: 1_700_500_000,
+  revocation_reason: "Key compromised",
+};
+
+function renderList(overrides: Partial<React.ComponentProps<typeof CertificateList>> = {}) {
+  const props = {
+    rows: [active],
+    isLoading: false,
+    error: null,
+    search: "",
+    onSearchChange: vi.fn(),
+    statusFilter: "all" as const,
+    onStatusFilterChange: vi.fn(),
+    ...overrides,
+  };
+  return { ...render(<CertificateList {...props} />), props };
+}
+
+describe("<CertificateList />", () => {
+  it("renders the serial as a link to the detail page", () => {
+    renderList();
+    const link = screen.getByRole("link", { name: String(active.serial_number) });
+    expect(link).toHaveAttribute("href", `/signer/certificates/${active.serial_number}`);
+  });
+
+  it("shows the empty state when no rows match the filters", () => {
+    renderList({ rows: [] });
+    expect(screen.getByRole("heading", { name: /no certificates yet/i })).toBeInTheDocument();
+  });
+
+  it("filters client-side by status", () => {
+    renderList({ rows: [active, revoked], statusFilter: "revoked" });
+    expect(
+      screen.queryByRole("link", { name: String(active.serial_number) }),
+    ).not.toBeInTheDocument();
+    expect(screen.getByRole("link", { name: String(revoked.serial_number) })).toBeInTheDocument();
+  });
+
+  it("surfaces an error state with a retry callback", () => {
+    const onRetry = vi.fn();
+    renderList({ error: new Error("boom"), onRetry });
+    expect(screen.getByText(/boom/)).toBeInTheDocument();
+  });
+});

--- a/web/src/features/core/signer/__tests__/RevokeCertificateDialog.test.tsx
+++ b/web/src/features/core/signer/__tests__/RevokeCertificateDialog.test.tsx
@@ -1,0 +1,56 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import { fireEvent, render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import { RevokeCertificateDialog } from "../components/RevokeCertificateDialog";
+
+function renderDialog(overrides: Partial<React.ComponentProps<typeof RevokeCertificateDialog>> = {}) {
+  const props = {
+    serialNumber: 42,
+    open: true,
+    onOpenChange: vi.fn(),
+    onSubmit: vi.fn(),
+    isPending: false,
+    ...overrides,
+  };
+  return { ...render(<RevokeCertificateDialog {...props} />), props };
+}
+
+describe("<RevokeCertificateDialog />", () => {
+  it("disables confirm until a reason is entered, then submits the trimmed reason", () => {
+    const { props } = renderDialog();
+    const confirm = screen.getByRole("button", { name: /confirm revoke/i });
+    expect(confirm).toBeDisabled();
+
+    fireEvent.change(screen.getByLabelText(/reason/i), { target: { value: "  compromised  " } });
+    expect(confirm).toBeEnabled();
+
+    fireEvent.click(confirm);
+    expect(props.onSubmit).toHaveBeenCalledWith("compromised");
+  });
+
+  it("surfaces an error message", () => {
+    renderDialog({ error: "You can only revoke your own certificates" });
+    expect(screen.getByText(/only revoke your own/i)).toBeInTheDocument();
+  });
+
+  it("shows a pending label while revoking", () => {
+    renderDialog({ isPending: true });
+    expect(screen.getByRole("button", { name: /revoking/i })).toBeDisabled();
+  });
+});

--- a/web/src/features/core/signer/__tests__/api.test.ts
+++ b/web/src/features/core/signer/__tests__/api.test.ts
@@ -1,0 +1,98 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { getCertificate, listCertificates, revokeCertificate } from "../api";
+
+const fetchMock = vi.fn();
+vi.stubGlobal("fetch", fetchMock as unknown as typeof fetch);
+
+function mockResponse(status: number, body: unknown): Response {
+  const text = typeof body === "string" ? body : JSON.stringify(body);
+  return new Response(text, { status, headers: { "content-type": "application/json" } });
+}
+
+afterEach(() => {
+  fetchMock.mockReset();
+});
+
+const certificate = {
+  serial_number: 42,
+  key_id: "k",
+  principal: "dev-admin",
+  public_key_fingerprint: "SHA256:pk",
+  ca_fingerprint: "SHA256:ca",
+  valid_after: 1_700_000_000,
+  valid_before: 4_102_444_800,
+  issued_at: 1_700_000_000,
+  revoked: false,
+};
+
+describe("listCertificates", () => {
+  it("round-trips pagination and returns the envelope", async () => {
+    fetchMock.mockResolvedValueOnce(
+      mockResponse(200, { certificates: [certificate], total: 1, limit: 20, offset: 0 }),
+    );
+    const result = await listCertificates({ limit: 20, offset: 0 });
+    expect(result.total).toBe(1);
+    expect(result.certificates).toHaveLength(1);
+    const url = fetchMock.mock.calls[0]?.[0] as string;
+    expect(url).toContain("/api/v1/signer/certificates");
+    expect(url).toContain("limit=20");
+    expect(url).toContain("offset=0");
+  });
+});
+
+describe("getCertificate", () => {
+  it("validates the response", async () => {
+    fetchMock.mockResolvedValueOnce(mockResponse(200, certificate));
+    const out = await getCertificate(42);
+    expect(out.serial_number).toBe(42);
+    expect(fetchMock.mock.calls[0]?.[0]).toContain("/api/v1/signer/certificates/42");
+  });
+});
+
+describe("revokeCertificate", () => {
+  it("POSTs the reason to /certificates/{serial}/revoke and parses the response", async () => {
+    fetchMock.mockResolvedValueOnce(
+      mockResponse(200, {
+        success: true,
+        message: "Certificate revoked successfully",
+        serial_number: 42,
+        revoked: true,
+        revoked_at: 1_700_500_000,
+        reason: "compromised",
+      }),
+    );
+    const out = await revokeCertificate(42, "compromised");
+    expect(out.revoked).toBe(true);
+    expect(out.reason).toBe("compromised");
+
+    const [url, init] = fetchMock.mock.calls[0] ?? [];
+    expect(url).toContain("/api/v1/signer/certificates/42/revoke");
+    expect(init?.method).toBe("POST");
+    const sent = JSON.parse(String(init?.body));
+    expect(sent).toEqual({ reason: "compromised" });
+  });
+
+  it("rejects when the backend denies the revoke (403)", async () => {
+    fetchMock.mockResolvedValueOnce(
+      mockResponse(403, { error: "forbidden", message: "Requires the signer:certificates:write privilege" }),
+    );
+    await expect(revokeCertificate(42, "compromised")).rejects.toThrow();
+  });
+});

--- a/web/src/features/core/signer/__tests__/queries.test.ts
+++ b/web/src/features/core/signer/__tests__/queries.test.ts
@@ -1,0 +1,35 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import { describe, expect, it } from "vitest";
+import { signerKeys } from "../queries";
+
+describe("signerKeys", () => {
+  it("namespaces under 'signer-certificates'", () => {
+    expect(signerKeys.all).toEqual(["signer-certificates"]);
+  });
+
+  it("list key carries the params", () => {
+    const params = { limit: 20, offset: 0 };
+    expect(signerKeys.list(params)).toEqual(["signer-certificates", "list", params]);
+  });
+
+  it("detail key stringifies the serial", () => {
+    expect(signerKeys.detail(42)).toEqual(["signer-certificates", "detail", "42"]);
+    expect(signerKeys.detail("42")).toEqual(["signer-certificates", "detail", "42"]);
+  });
+});

--- a/web/src/features/core/signer/__tests__/status.test.ts
+++ b/web/src/features/core/signer/__tests__/status.test.ts
@@ -1,0 +1,68 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import { describe, expect, it } from "vitest";
+import type { Certificate } from "../schemas";
+import {
+  formatCertificateLifetime,
+  getCertificateStatus,
+  statusBadgeVariantFromCertificateStatus,
+} from "../status";
+
+const base: Certificate = {
+  serial_number: 1,
+  key_id: "k",
+  principal: "p",
+  public_key_fingerprint: "SHA256:pk",
+  ca_fingerprint: "SHA256:ca",
+  valid_after: 1_700_000_000,
+  valid_before: 1_700_086_400,
+  issued_at: 1_700_000_000,
+  revoked: false,
+};
+
+const now = new Date(1_700_043_200 * 1000); // midway through the validity window
+
+describe("getCertificateStatus", () => {
+  it("returns revoked when revoked, regardless of validity", () => {
+    expect(getCertificateStatus({ ...base, revoked: true }, now)).toBe("revoked");
+  });
+
+  it("returns expired when valid_before is in the past", () => {
+    expect(getCertificateStatus({ ...base, valid_before: 1_600_000_000 }, now)).toBe("expired");
+  });
+
+  it("returns active within the validity window", () => {
+    expect(getCertificateStatus(base, now)).toBe("active");
+  });
+});
+
+describe("statusBadgeVariantFromCertificateStatus", () => {
+  it("maps each status to a badge variant", () => {
+    expect(statusBadgeVariantFromCertificateStatus("active")).toBe("active");
+    expect(statusBadgeVariantFromCertificateStatus("expired")).toBe("expired");
+    expect(statusBadgeVariantFromCertificateStatus("revoked")).toBe("deleted");
+  });
+});
+
+describe("formatCertificateLifetime", () => {
+  it("renders whole-hour lifetimes", () => {
+    expect(formatCertificateLifetime({ ...base, valid_after: 0, valid_before: 7200 })).toBe(
+      "2 hours",
+    );
+  });
+});

--- a/web/src/features/core/signer/api.ts
+++ b/web/src/features/core/signer/api.ts
@@ -1,0 +1,58 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+// Calls are namespaced under /signer so the proxy routes them to the signer
+// service with the user's Bearer.
+import { apiFetch } from "@/shared/api/client";
+import {
+  type Certificate,
+  type CertificateList,
+  type RevokeResponse,
+  certificateListSchema,
+  certificateSchema,
+  revokeResponseSchema,
+} from "./schemas";
+import type { CertificateListParams } from "./types";
+
+export async function listCertificates(
+  params: CertificateListParams = {},
+): Promise<CertificateList> {
+  const search = new URLSearchParams();
+  if (typeof params.limit === "number") search.set("limit", String(params.limit));
+  if (typeof params.offset === "number") search.set("offset", String(params.offset));
+  const qs = search.toString();
+  const raw = await apiFetch(`/signer/certificates${qs ? `?${qs}` : ""}`);
+  return certificateListSchema.parse(raw);
+}
+
+export async function getCertificate(serial: number | string): Promise<Certificate> {
+  const raw = await apiFetch(`/signer/certificates/${serial}`);
+  return certificateSchema.parse(raw);
+}
+
+// serial comes from the certificate; the backend keys revocation off the real
+// serial_number (never a key id or timestamp).
+export async function revokeCertificate(
+  serial: number,
+  reason: string,
+): Promise<RevokeResponse> {
+  const raw = await apiFetch(`/signer/certificates/${serial}/revoke`, {
+    method: "POST",
+    body: { reason },
+  });
+  return revokeResponseSchema.parse(raw);
+}

--- a/web/src/features/core/signer/components/CertificateDetail.tsx
+++ b/web/src/features/core/signer/components/CertificateDetail.tsx
@@ -1,0 +1,176 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+"use client";
+
+import { Calendar, Fingerprint, UserSquare } from "lucide-react";
+import * as React from "react";
+import { toast } from "sonner";
+import { useAbility } from "@/shared/casl/AbilityProvider";
+import { Button } from "@/shared/ui/button";
+import { ErrorState } from "@/shared/ui/ErrorState";
+import { CardSkeleton } from "@/shared/ui/Loading";
+import { MetaItem, MetaRow } from "@/shared/ui/MetaRow";
+import { useCertificate, useRevokeCertificate } from "../queries";
+import type { Certificate } from "../schemas";
+import {
+  CERTIFICATE_STATUS_LABELS,
+  type CertificateStatus,
+  formatCertificateLifetime,
+  formatUnixSeconds,
+  getCertificateStatus,
+} from "../status";
+import { RevokeCertificateDialog } from "./RevokeCertificateDialog";
+
+export type CertificateDetailProps = {
+  serial: string;
+};
+
+const STATUS_TONE: Record<CertificateStatus, "success" | "warning" | "danger"> = {
+  active: "success",
+  expired: "warning",
+  revoked: "danger",
+};
+
+export function CertificateDetail({ serial }: CertificateDetailProps) {
+  const ability = useAbility();
+  const query = useCertificate(serial);
+  const revoke = useRevokeCertificate();
+  const [dialogOpen, setDialogOpen] = React.useState(false);
+  const [revokeError, setRevokeError] = React.useState<string | null>(null);
+
+  if (query.isLoading) return <CardSkeleton />;
+  if (query.error) {
+    return (
+      <ErrorState message={(query.error as Error).message} onRetry={() => query.refetch()} />
+    );
+  }
+  const cert = query.data;
+  if (!cert) return null;
+
+  const status = getCertificateStatus(cert);
+  const canRevoke = ability.can("manage", "Signer") && !cert.revoked;
+
+  return (
+    <section className="space-y-6">
+      <header className="space-y-4">
+        <div className="flex flex-wrap items-start justify-between gap-3">
+          <h1 className="font-display text-[28px] font-bold leading-tight text-foreground">
+            Certificate {cert.serial_number}
+          </h1>
+          {canRevoke ? (
+            <Button
+              variant="destructive"
+              onClick={() => {
+                setRevokeError(null);
+                setDialogOpen(true);
+              }}
+            >
+              Revoke
+            </Button>
+          ) : null}
+        </div>
+        <MetaRow>
+          <MetaItem
+            variant="status"
+            tone={STATUS_TONE[status]}
+            value={CERTIFICATE_STATUS_LABELS[status]}
+          />
+          <MetaItem icon={UserSquare} label="Principal" value={cert.principal} />
+          <MetaItem icon={Calendar} label="Valid until" value={formatUnixSeconds(cert.valid_before)} />
+          <MetaItem icon={Fingerprint} label="Lifetime" value={formatCertificateLifetime(cert)} />
+        </MetaRow>
+      </header>
+
+      <CertificateMetadata cert={cert} />
+
+      <RevokeCertificateDialog
+        serialNumber={cert.serial_number}
+        open={dialogOpen}
+        onOpenChange={setDialogOpen}
+        isPending={revoke.isPending}
+        error={revokeError}
+        onSubmit={(reason) => {
+          setRevokeError(null);
+          revoke.mutate(
+            { serial: cert.serial_number, reason },
+            {
+              onSuccess: (res) => {
+                setDialogOpen(false);
+                toast.success(
+                  res.already_revoked
+                    ? "Certificate was already revoked"
+                    : "Certificate revoked",
+                );
+              },
+              onError: (err) =>
+                setRevokeError(err instanceof Error ? err.message : "Revoke failed"),
+            },
+          );
+        }}
+      />
+    </section>
+  );
+}
+
+function CertificateMetadata({ cert }: { cert: Certificate }) {
+  const items: Array<{ label: string; value: React.ReactNode }> = [
+    { label: "Serial number", value: <span className="font-mono">{cert.serial_number}</span> },
+    { label: "Key ID", value: <span className="break-all font-mono text-xs">{cert.key_id}</span> },
+    { label: "Principal", value: cert.principal },
+    {
+      label: "Public key fingerprint",
+      value: <span className="break-all font-mono text-xs">{cert.public_key_fingerprint}</span>,
+    },
+    {
+      label: "CA fingerprint",
+      value: <span className="break-all font-mono text-xs">{cert.ca_fingerprint}</span>,
+    },
+    { label: "Issued at", value: formatUnixSeconds(cert.issued_at) },
+    { label: "Valid after", value: formatUnixSeconds(cert.valid_after) },
+    { label: "Valid before", value: formatUnixSeconds(cert.valid_before) },
+    { label: "Source IP", value: cert.source_ip || "—" },
+    {
+      label: "Granted extensions",
+      value: cert.granted_extensions?.length ? cert.granted_extensions.join(", ") : "—",
+    },
+    { label: "Force command", value: cert.force_command || "—" },
+  ];
+
+  if (cert.revoked) {
+    items.push(
+      {
+        label: "Revoked at",
+        value: cert.revoked_at != null ? formatUnixSeconds(cert.revoked_at) : "—",
+      },
+      { label: "Revocation reason", value: cert.revocation_reason || "—" },
+    );
+  }
+
+  return (
+    <dl className="grid grid-cols-1 gap-x-8 gap-y-4 rounded-lg border bg-card p-5 sm:grid-cols-2">
+      {items.map((item) => (
+        <div key={item.label} className="space-y-1">
+          <dt className="text-xs font-medium uppercase tracking-wide text-muted-foreground">
+            {item.label}
+          </dt>
+          <dd className="text-sm text-foreground">{item.value}</dd>
+        </div>
+      ))}
+    </dl>
+  );
+}

--- a/web/src/features/core/signer/components/CertificateList.tsx
+++ b/web/src/features/core/signer/components/CertificateList.tsx
@@ -1,0 +1,181 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+"use client";
+
+import Link from "next/link";
+import * as React from "react";
+import { DataTable, type DataTableColumn, type DataTablePagination } from "@/shared/ui/DataTable";
+import { EmptyState } from "@/shared/ui/EmptyState";
+import { ErrorState } from "@/shared/ui/ErrorState";
+import { Input } from "@/shared/ui/input";
+import { TableSkeleton } from "@/shared/ui/Loading";
+import { StatusBadge } from "@/shared/ui/StatusBadge";
+import type { Certificate } from "../schemas";
+import {
+  CERTIFICATE_STATUS_LABELS,
+  type CertificateStatus,
+  formatUnixDate,
+  getCertificateStatus,
+  statusBadgeVariantFromCertificateStatus,
+} from "../status";
+
+export type CertificateListProps = {
+  rows: Certificate[];
+  isLoading: boolean;
+  error: Error | null;
+  onRetry?: () => void;
+  search: string;
+  onSearchChange: (next: string) => void;
+  statusFilter: CertificateStatus | "all";
+  onStatusFilterChange: (next: CertificateStatus | "all") => void;
+  pagination?: DataTablePagination;
+};
+
+export function CertificateList({
+  rows,
+  isLoading,
+  error,
+  onRetry,
+  search,
+  onSearchChange,
+  statusFilter,
+  onStatusFilterChange,
+  pagination,
+}: CertificateListProps) {
+  // Status/search narrow only the current server page — the signer API paginates
+  // by limit/offset and has no status filter, so deeper filtering is client-side.
+  const filtered = React.useMemo(() => {
+    const needle = search.trim().toLowerCase();
+    return rows.filter((row) => {
+      if (statusFilter !== "all" && getCertificateStatus(row) !== statusFilter) return false;
+      if (needle) {
+        const hay = `${row.serial_number} ${row.principal} ${row.key_id}`.toLowerCase();
+        if (!hay.includes(needle)) return false;
+      }
+      return true;
+    });
+  }, [rows, search, statusFilter]);
+
+  const columns: Array<DataTableColumn<Certificate>> = [
+    {
+      key: "serial",
+      header: "Serial",
+      sortable: true,
+      sortValue: (row) => row.serial_number,
+      cell: (row) => (
+        <Link
+          href={`/signer/certificates/${row.serial_number}`}
+          className="font-mono font-medium text-foreground hover:underline"
+        >
+          {row.serial_number}
+        </Link>
+      ),
+    },
+    {
+      key: "principal",
+      header: "Principal",
+      sortable: true,
+      sortValue: (row) => row.principal,
+      cell: (row) => <span className="text-sm">{row.principal}</span>,
+    },
+    {
+      key: "issued",
+      header: "Issued",
+      sortable: true,
+      sortValue: (row) => row.issued_at,
+      cell: (row) => (
+        <span className="text-sm text-muted-foreground">{formatUnixDate(row.issued_at)}</span>
+      ),
+    },
+    {
+      key: "validBefore",
+      header: "Valid until",
+      sortable: true,
+      sortValue: (row) => row.valid_before,
+      cell: (row) => (
+        <span className="text-sm text-muted-foreground">{formatUnixDate(row.valid_before)}</span>
+      ),
+    },
+    {
+      key: "status",
+      header: "Status",
+      sortable: true,
+      sortValue: (row) => getCertificateStatus(row),
+      cell: (row) => {
+        const status = getCertificateStatus(row);
+        return (
+          <StatusBadge
+            variant={statusBadgeVariantFromCertificateStatus(status)}
+            label={CERTIFICATE_STATUS_LABELS[status]}
+          />
+        );
+      },
+    },
+  ];
+
+  return (
+    <div className="space-y-6">
+      <div>
+        <h1 className="font-display text-[28px] font-bold leading-tight">SSH Certificates</h1>
+        <p className="mt-1 text-sm text-muted-foreground">
+          SSH certificates issued to you by the certificate signer.
+        </p>
+      </div>
+
+      <div className="flex flex-col gap-3 rounded-md border bg-card p-4 sm:flex-row sm:items-center">
+        <Input
+          type="search"
+          placeholder="Search by serial, principal, or key ID"
+          value={search}
+          onChange={(e) => onSearchChange(e.target.value)}
+          aria-label="Search certificates"
+          className="sm:w-72"
+        />
+        <select
+          value={statusFilter}
+          onChange={(e) => onStatusFilterChange(e.target.value as CertificateStatus | "all")}
+          aria-label="Filter by status"
+          className="h-9 rounded-md border bg-background px-3 text-sm"
+        >
+          <option value="all">All statuses</option>
+          <option value="active">Active</option>
+          <option value="expired">Expired</option>
+          <option value="revoked">Revoked</option>
+        </select>
+      </div>
+
+      {isLoading ? (
+        <TableSkeleton rows={6} columns={5} />
+      ) : error ? (
+        <ErrorState message={error.message} onRetry={onRetry} />
+      ) : filtered.length === 0 ? (
+        <EmptyState
+          heading="No certificates yet"
+          description="No certificates match the current filters."
+        />
+      ) : (
+        <DataTable
+          columns={columns}
+          rows={filtered}
+          rowKey={(row) => String(row.serial_number)}
+          pagination={pagination}
+        />
+      )}
+    </div>
+  );
+}

--- a/web/src/features/core/signer/components/RevokeCertificateDialog.tsx
+++ b/web/src/features/core/signer/components/RevokeCertificateDialog.tsx
@@ -1,0 +1,99 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+"use client";
+
+import * as React from "react";
+import { Button } from "@/shared/ui/button";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/shared/ui/dialog";
+import { Input } from "@/shared/ui/input";
+import { Label } from "@/shared/ui/label";
+
+export type RevokeCertificateDialogProps = {
+  serialNumber: number;
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  onSubmit: (reason: string) => void;
+  isPending: boolean;
+  error?: string | null;
+};
+
+export function RevokeCertificateDialog({
+  serialNumber,
+  open,
+  onOpenChange,
+  onSubmit,
+  isPending,
+  error,
+}: RevokeCertificateDialogProps) {
+  const [reason, setReason] = React.useState("");
+
+  React.useEffect(() => {
+    if (!open) setReason("");
+  }, [open]);
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent>
+        <DialogHeader>
+          <DialogTitle>Revoke certificate?</DialogTitle>
+          <DialogDescription>
+            This revokes certificate serial {serialNumber}. This cannot be undone.
+          </DialogDescription>
+        </DialogHeader>
+        <form
+          className="space-y-4"
+          onSubmit={(e) => {
+            e.preventDefault();
+            const trimmed = reason.trim();
+            if (!trimmed) return;
+            onSubmit(trimmed);
+          }}
+        >
+          <div className="space-y-2">
+            <Label htmlFor="revoke-reason">Reason</Label>
+            <Input
+              id="revoke-reason"
+              value={reason}
+              onChange={(e) => setReason(e.target.value)}
+              placeholder="Why is this certificate being revoked?"
+              required
+            />
+          </div>
+          {error ? (
+            <p className="text-sm text-[color:var(--custos-red-700)]">{error}</p>
+          ) : null}
+          <DialogFooter>
+            <Button type="button" variant="outline" onClick={() => onOpenChange(false)}>
+              Cancel
+            </Button>
+            <Button type="submit" variant="destructive" disabled={isPending || !reason.trim()}>
+              {isPending ? "Revoking…" : "Confirm revoke"}
+            </Button>
+          </DialogFooter>
+        </form>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/web/src/features/core/signer/queries.ts
+++ b/web/src/features/core/signer/queries.ts
@@ -1,0 +1,67 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+"use client";
+
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { getCertificate, listCertificates, revokeCertificate } from "./api";
+import type { CertificateListParams } from "./types";
+
+export const signerKeys = {
+  all: ["signer-certificates"] as const,
+  list: (params: CertificateListParams = {}) => [...signerKeys.all, "list", params] as const,
+  detail: (serial: number | string) => [...signerKeys.all, "detail", String(serial)] as const,
+};
+
+const DEFAULTS = {
+  staleTime: 30_000,
+  gcTime: 300_000,
+  refetchOnWindowFocus: false,
+} as const;
+
+export function useCertificates(params: CertificateListParams = {}) {
+  return useQuery({
+    queryKey: signerKeys.list(params),
+    queryFn: () => listCertificates(params),
+    ...DEFAULTS,
+  });
+}
+
+export function useCertificate(serial: number | string | undefined) {
+  return useQuery({
+    queryKey:
+      serial !== undefined && serial !== ""
+        ? signerKeys.detail(serial)
+        : [...signerKeys.all, "detail", "none"],
+    queryFn: () => getCertificate(serial as number | string),
+    enabled: serial !== undefined && serial !== "",
+    ...DEFAULTS,
+  });
+}
+
+export function useRevokeCertificate() {
+  const client = useQueryClient();
+  return useMutation({
+    mutationFn: ({ serial, reason }: { serial: number; reason: string }) =>
+      revokeCertificate(serial, reason),
+    // Re-fetch from the backend rather than faking revoked state in React.
+    onSuccess: (_data, { serial }) => {
+      client.invalidateQueries({ queryKey: signerKeys.all });
+      client.invalidateQueries({ queryKey: signerKeys.detail(serial) });
+    },
+  });
+}

--- a/web/src/features/core/signer/schemas.ts
+++ b/web/src/features/core/signer/schemas.ts
@@ -1,0 +1,61 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+// TODO(openapi): replace with generated once the SSH Certificate Signer ships
+// an OpenAPI spec; the signer is a separate extension service with no spec today.
+import { z } from "zod";
+
+// Mirrors extensions/SSH-Certificate-Signer CertificateResponse. Unix-second
+// timestamps are passed through as numbers and formatted in the UI layer.
+export const certificateSchema = z.object({
+  serial_number: z.number().int(),
+  key_id: z.string(),
+  principal: z.string(),
+  public_key_fingerprint: z.string(),
+  ca_fingerprint: z.string(),
+  valid_after: z.number().int(),
+  valid_before: z.number().int(),
+  issued_at: z.number().int(),
+  source_ip: z.string().optional(),
+  granted_extensions: z.array(z.string()).optional(),
+  force_command: z.string().nullable().optional(),
+  revoked: z.boolean(),
+  revoked_at: z.number().int().nullable().optional(),
+  revocation_reason: z.string().optional(),
+});
+export type Certificate = z.infer<typeof certificateSchema>;
+
+export const certificateListSchema = z.object({
+  certificates: z.array(certificateSchema),
+  total: z.number().int().nonnegative(),
+  limit: z.number().int(),
+  offset: z.number().int(),
+});
+export type CertificateList = z.infer<typeof certificateListSchema>;
+
+// Response from POST /signer/certificates/{serial}/revoke. already_revoked is
+// true when the certificate was revoked by a prior request (idempotent success).
+export const revokeResponseSchema = z.object({
+  success: z.boolean(),
+  message: z.string(),
+  serial_number: z.number().int(),
+  revoked: z.boolean(),
+  revoked_at: z.number().int(),
+  reason: z.string(),
+  already_revoked: z.boolean().optional(),
+});
+export type RevokeResponse = z.infer<typeof revokeResponseSchema>;

--- a/web/src/features/core/signer/status.ts
+++ b/web/src/features/core/signer/status.ts
@@ -1,0 +1,65 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import type { StatusBadgeVariant } from "@/shared/ui/StatusBadge";
+import type { Certificate } from "./schemas";
+
+export type CertificateStatus = "active" | "expired" | "revoked";
+
+export const CERTIFICATE_STATUS_LABELS: Record<CertificateStatus, string> = {
+  active: "Active",
+  expired: "Expired",
+  revoked: "Revoked",
+};
+
+// Revocation takes precedence over time-based validity.
+export function getCertificateStatus(cert: Certificate, now: Date = new Date()): CertificateStatus {
+  if (cert.revoked) return "revoked";
+  const nowSeconds = Math.floor(now.getTime() / 1000);
+  if (cert.valid_before < nowSeconds) return "expired";
+  return "active";
+}
+
+export function statusBadgeVariantFromCertificateStatus(
+  status: CertificateStatus,
+): StatusBadgeVariant {
+  if (status === "active") return "active";
+  if (status === "expired") return "expired";
+  return "deleted";
+}
+
+export function formatUnixSeconds(seconds: number): string {
+  return new Date(seconds * 1000).toLocaleString();
+}
+
+export function formatUnixDate(seconds: number): string {
+  return new Date(seconds * 1000).toLocaleDateString(undefined, {
+    year: "numeric",
+    month: "short",
+    day: "numeric",
+  });
+}
+
+export function formatCertificateLifetime(cert: Certificate): string {
+  const seconds = Math.max(0, cert.valid_before - cert.valid_after);
+  const hours = Math.floor(seconds / 3600);
+  const minutes = Math.floor((seconds % 3600) / 60);
+  if (hours > 0 && minutes === 0) return `${hours} hour${hours === 1 ? "" : "s"}`;
+  if (hours > 0) return `${hours}h ${minutes}m`;
+  if (minutes > 0) return `${minutes} minute${minutes === 1 ? "" : "s"}`;
+  return `${seconds} seconds`;
+}

--- a/web/src/features/core/signer/types.ts
+++ b/web/src/features/core/signer/types.ts
@@ -1,0 +1,23 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+// The signer list endpoint scopes to the authenticated user's email and
+// supports only limit/offset; status is derived client-side (see status.ts).
+export type CertificateListParams = {
+  limit?: number;
+  offset?: number;
+};

--- a/web/src/lib/env.ts
+++ b/web/src/lib/env.ts
@@ -24,6 +24,9 @@ export const serverSchema = z.object({
 
   CUSTOS_CORE_API_BASE_URL: z.string().url().default("http://localhost:8080"),
 
+  // SSH Certificate Signer (separate service; proxy routes /signer/* here).
+  CUSTOS_SIGNER_API_BASE_URL: z.string().url().default("http://localhost:8084"),
+
   OIDC_ISSUER_URL: z.string().url(),
   OIDC_CLIENT_ID: z.string().min(1),
   OIDC_CLIENT_SECRET: z.string().min(1),

--- a/web/src/mocks/handlers.ts
+++ b/web/src/mocks/handlers.ts
@@ -25,6 +25,7 @@ import { organizationsHandlers } from "./handlers/organizations";
 import { privilegesHandlers } from "./handlers/privileges";
 import { projectsHandlers } from "./handlers/projects";
 import { resourcesHandlers } from "./handlers/resources";
+import { signerHandlers } from "./handlers/signer";
 import { tracesHandlers } from "./handlers/traces";
 
 export const handlers: RequestHandler[] = [
@@ -38,4 +39,5 @@ export const handlers: RequestHandler[] = [
   ...amieHandlers,
   ...clustersHandlers,
   ...resourcesHandlers,
+  ...signerHandlers,
 ];

--- a/web/src/mocks/handlers/privileges.ts
+++ b/web/src/mocks/handlers/privileges.ts
@@ -40,6 +40,8 @@ const ALL_PRIVILEGES: Privilege[] = [
   "amie:replies:write",
   "amie:unmapped:read",
   "amie:unmapped:write",
+  "signer:certificates:read",
+  "signer:certificates:write",
 ];
 
 // Test seam: e2e scopes privileges per persona via a non-httpOnly cookie.

--- a/web/src/mocks/handlers/signer.ts
+++ b/web/src/mocks/handlers/signer.ts
@@ -1,0 +1,73 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import { http, HttpResponse } from "msw";
+import certificatesFixture from "@/features/core/signer/__fixtures__/certificates.json";
+import type { Certificate } from "@/features/core/signer/schemas";
+
+const certificates: Certificate[] = (certificatesFixture as Certificate[]).map((c) => ({ ...c }));
+
+export const signerHandlers = [
+  http.get("*/api/v1/signer/certificates", ({ request }) => {
+    const url = new URL(request.url);
+    const limit = Number(url.searchParams.get("limit") ?? certificates.length);
+    const offset = Number(url.searchParams.get("offset") ?? 0);
+    const items = certificates.slice(offset, offset + limit);
+    return HttpResponse.json({
+      certificates: items,
+      total: certificates.length,
+      limit,
+      offset,
+    });
+  }),
+
+  http.get("*/api/v1/signer/certificates/:serial", ({ params }) => {
+    const serial = Number(params.serial);
+    const found = certificates.find((c) => c.serial_number === serial);
+    if (!found) return HttpResponse.json({ error: "certificate not found" }, { status: 404 });
+    return HttpResponse.json(found);
+  }),
+
+  http.post("*/api/v1/signer/certificates/:serial/revoke", async ({ params, request }) => {
+    const serial = Number(params.serial);
+    const cert = certificates.find((c) => c.serial_number === serial);
+    if (!cert) return HttpResponse.json({ error: "certificate not found" }, { status: 404 });
+
+    const body = (await request.json().catch(() => ({}))) as { reason?: string };
+    const reason = (body.reason ?? "").trim();
+
+    // Idempotent: a repeat revoke returns the existing state without re-mutating.
+    const alreadyRevoked = cert.revoked;
+    if (!alreadyRevoked) {
+      cert.revoked = true;
+      cert.revoked_at = Math.floor(Date.now() / 1000);
+      cert.revocation_reason = reason;
+    }
+
+    return HttpResponse.json({
+      success: true,
+      message: alreadyRevoked
+        ? "Certificate was already revoked"
+        : "Certificate revoked successfully",
+      serial_number: serial,
+      revoked: true,
+      revoked_at: cert.revoked_at ?? Math.floor(Date.now() / 1000),
+      reason: cert.revocation_reason ?? reason,
+      already_revoked: alreadyRevoked,
+    });
+  }),
+];

--- a/web/src/shared/casl/abilities.ts
+++ b/web/src/shared/casl/abilities.ts
@@ -48,6 +48,8 @@ export const PRIVILEGE_ABILITY_MAP: Record<string, PrivilegeRule[]> = {
   "amie:replies:write": [{ action: "manage", subject: "AMIE" }],
   "amie:unmapped:read": [{ action: "read", subject: "AMIE" }],
   "amie:unmapped:write": [{ action: "manage", subject: "AMIE" }],
+  "signer:certificates:read": [{ action: "read", subject: "Signer" }],
+  "signer:certificates:write": [{ action: "manage", subject: "Signer" }],
 };
 
 export function defineAbilitiesFor(privileges: Privilege[]): AppAbility {

--- a/web/src/shared/layout/nav.ts
+++ b/web/src/shared/layout/nav.ts
@@ -21,6 +21,7 @@ import {
   ClipboardList,
   FolderKanban,
   HardDrive,
+  KeyRound,
   type LucideIcon,
   Server,
   UserCog,
@@ -57,6 +58,13 @@ export const portalNav: NavItem[] = [
     icon: FolderKanban,
     group: "allocations",
     ability: { action: "read", subject: "Project" },
+  },
+  {
+    href: "/signer/certificates",
+    label: "SSH Certificates",
+    icon: KeyRound,
+    group: "allocations",
+    ability: { action: "read", subject: "Signer" },
   },
   {
     href: "/admin/users",

--- a/web/tests/fixtures/auth.ts
+++ b/web/tests/fixtures/auth.ts
@@ -64,6 +64,8 @@ const PRIVILEGES: Record<Persona, string[]> = {
     "amie:replies:write",
     "amie:unmapped:read",
     "amie:unmapped:write",
+    "signer:certificates:read",
+    "signer:certificates:write",
   ],
 };
 

--- a/web/tests/signer-certificates.e2e.ts
+++ b/web/tests/signer-certificates.e2e.ts
@@ -1,0 +1,75 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import AxeBuilder from "@axe-core/playwright";
+import { expect, test } from "@playwright/test";
+import { signInAs } from "./fixtures/auth";
+
+test.describe("ssh certificates", () => {
+  test("lists certificates and navigates to a detail page", async ({ page }) => {
+    await signInAs(page, "admin");
+    await page.goto("/signer/certificates");
+    await expect(page.getByRole("heading", { name: /^SSH Certificates$/ })).toBeVisible();
+
+    const firstRow = page.locator('a[href^="/signer/certificates/"]').first();
+    await expect(firstRow).toBeVisible({ timeout: 15_000 });
+    await firstRow.click();
+    await expect(page).toHaveURL(/\/signer\/certificates\/\d+/);
+    await expect(page.getByRole("heading", { name: /^Certificate \d+$/ })).toBeVisible();
+  });
+
+  test("status filter updates URL state", async ({ page }) => {
+    await signInAs(page, "admin");
+    await page.goto("/signer/certificates");
+    await page.getByLabel(/filter by status/i).selectOption("revoked");
+    await expect(page).toHaveURL(/[?&]status=revoked/);
+  });
+
+  test("shows the revoked status on an already-revoked certificate", async ({ page }) => {
+    await signInAs(page, "admin");
+    await page.goto("/signer/certificates/44");
+    await expect(page.getByRole("heading", { name: /^Certificate 44$/ })).toBeVisible();
+    await expect(page.getByText(/Key compromised/).first()).toBeVisible({ timeout: 15_000 });
+  });
+
+  test("revokes an active certificate and reflects backend state", async ({ page }) => {
+    await signInAs(page, "admin");
+    await page.goto("/signer/certificates/42");
+    await expect(page.getByRole("heading", { name: /^Certificate 42$/ })).toBeVisible();
+
+    await page.getByRole("button", { name: /^Revoke$/ }).click();
+    await page.getByLabel(/reason/i).fill("Compromised in e2e");
+    await page.getByRole("button", { name: /^Confirm revoke$/ }).click();
+
+    // The detail refetches after revoke and shows backend state (reason + no
+    // remaining Revoke button), rather than a faked client-side update. The
+    // button's absence also means a double-revoke can't be triggered from the UI.
+    await expect(page.getByText(/Compromised in e2e/).first()).toBeVisible({ timeout: 15_000 });
+    await expect(page.getByRole("button", { name: /^Revoke$/ })).toHaveCount(0);
+  });
+
+  test("axe sweep on certificates list", async ({ page }) => {
+    await signInAs(page, "admin");
+    await page.goto("/signer/certificates");
+    await expect(page.getByRole("heading", { name: /^SSH Certificates$/ })).toBeVisible();
+    const results = await new AxeBuilder({ page }).withTags(["wcag2a", "wcag2aa"]).analyze();
+    const blocking = results.violations.filter(
+      (v) => v.impact === "serious" || v.impact === "critical",
+    );
+    expect(blocking, JSON.stringify(blocking, null, 2)).toEqual([]);
+  });
+});


### PR DESCRIPTION
## Summary

Integrates SSH certificate management into the current Custos web dashboard.

### Included

- certificate list and detail pages
- active, expired, and revoked status display
- signer navigation and privilege mappings
- signer API proxy configuration
- certificate revocation with a reason
- improved idempotent revocation persistence
- MSW handlers and frontend tests

### Authorization

- `signer:certificates:read` controls access to certificate views
- `signer:certificates:write` controls administrative revoke functionality
- the existing machine-to-machine signer revoke endpoint is preserved

### Out of scope

KRL generation, KRL publication, shared-filesystem synchronization, workers, batching, and login-node configuration are intentionally excluded from this PR.

This implementation replaces the earlier standalone portal approach and targets the current repository architecture.

## Verification

- `go build ./...`
- `go vet ./...`
- `go test ./...`
- relevant web lint, type-check, unit, and end-to-end tests